### PR TITLE
replaced docsplit with pdf-reader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+# Ignore Mac DS_Store files
+**/.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,3 +9,6 @@ This project *tries* to adhere to [Semantic Versioning](http://semver.org/), eve
 ## [1.1.0]
 - This gem was refactored using the [CLI Template](https://github.com/tongueroo/cli-template), a generator tool that builds a starter CLI project.
 - Initial public release
+
+## [1.1.4]
+- Replaced Docsplit and pdf2text gems, which rely on command-line tools with pdf-reader gem, which does not

--- a/inspec_tools.gemspec
+++ b/inspec_tools.gemspec
@@ -30,17 +30,16 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'activesupport', '>= 4.2.3'
+  spec.add_dependency 'activesupport', '~> 4.2', '>= 4.2.3'
   spec.add_dependency 'colorize', '~> 0'
-  spec.add_dependency 'docsplit', '~> 0.7.6'
   spec.add_dependency 'inspec', '~> 2.2'
   spec.add_dependency 'nokogiri', '~> 1.8'
   spec.add_dependency 'nokogiri-happymapper', '~> 0'
   spec.add_dependency 'OptionParser', '~> 0'
-  spec.add_dependency 'pdftotext', '0.2.1'
+  spec.add_dependency 'pdf-reader', '~> 2.1', '>= 2.1.0'
   spec.add_dependency 'roo', '~> 2.7'
   spec.add_dependency 'thor', '~> 0.19'
-  spec.add_dependency 'word_wrap', '~> 1.0.0'
+  spec.add_dependency 'word_wrap', '~> 1.0', '~> 1.0.0'
   spec.add_development_dependency 'bundler', '~> 1.12'
   spec.add_development_dependency 'minitest', '~> 5.0'
   spec.add_development_dependency 'pry', '~> 0'

--- a/lib/data/debug_text
+++ b/lib/data/debug_text
@@ -13,7 +13,7 @@ has been copied over to the new partition, unmount it and then remove the data f
 directory that was in the old partition. Otherwise it will still consume space in the old
 partition that will be masked when the new filesystem is mounted. For example, if a system
 is in single-user mode with no filesystems mounted and the administrator adds a lot of data
-to the /tmp directory, this data will still consume space in / once the /tmp filesystem is
+to the/tmp directory, this data will still consume spa/eonce the /tmpfilesystem is
 mounted unless it is removed first.
 
 1.1.1 Disable unused filesystems
@@ -49,7 +49,7 @@ install /bin/true
 # lsmod | grep cramfs
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fil/etc/modprobe.d/CIS.conf   and add the following line:
 install cramfs /bin/true
 
 
@@ -57,7 +57,7 @@ install cramfs /bin/true
 1.1.1.2 Ensure mounting of freevxfs filesystems is disabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The freevxfs filesystem type is a free version of the Veritas type filesystem. This is the
+The freevxfs  filesystem type is a free version of the Veritas type filesystem. This is the
 primary filesystem type for HP-UX operating systems.
 Rationale:
 Removing support for unneeded filesystem types reduces the local attack surface of the
@@ -69,7 +69,7 @@ install /bin/true
 # lsmod | grep freevxfs
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fi/etc/modprobe.d/CIS.conf   and add the following line:
 install freevxfs /bin/true
 
 
@@ -89,7 +89,7 @@ install /bin/true
 # lsmod | grep jffs2
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fi/etc/modprobe.d/CIS.conf   and add the following line:
 install jffs2 /bin/true
 
 
@@ -109,7 +109,7 @@ install /bin/true
 # lsmod | grep hfs
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fi/etc/modprobe.d/CIS.conf   and add the following line:
 install hfs /bin/true
 
 
@@ -117,7 +117,7 @@ install hfs /bin/true
 1.1.1.5 Ensure mounting of hfsplus filesystems is disabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The hfsplus filesystem type is a hierarchical filesystem designed to replace hfs that
+The hfsplus  filesystem type is a hierarchical filesystem designed to replhfs that
 allows you to mount Mac OS filesystems.
 Rationale:
 Removing support for unneeded filesystem types reduces the local attack surface of the
@@ -129,7 +129,7 @@ install /bin/true
 # lsmod | grep hfsplus
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fi/etc/modprobe.d/CIS.conf   and add the following line:
 install hfsplus /bin/true
 
 
@@ -137,8 +137,8 @@ install hfsplus /bin/true
 1.1.1.6 Ensure mounting of squashfs filesystems is disabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The squashfs filesystem type is a compressed read-only Linux filesystem embedded in
-small footprint systems (similar to cramfs). A squashfs image can be used without having
+The squashfs  filesystem type is a compressed read-only Linux filesystem embedded in
+small footprint systems (similar tocramfs). Asquashfs  image can be used without having
 to first decompress the image.
 Rationale:
 Removing support for unneeded filesystem types reduces the local attack surface of the
@@ -150,7 +150,7 @@ install /bin/true
 # lsmod | grep squashfs
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fi/etc/modprobe.d/CIS.conf   and add the following line:
 install squashfs /bin/true
 
 
@@ -172,7 +172,7 @@ install /bin/true
 # lsmod | grep udf
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fi/etc/modprobe.d/CIS.conf   and add the following line:
 install udf /bin/true
 
 
@@ -181,7 +181,7 @@ install udf /bin/true
 Profile Applicability: Level 1 - Server Level 2 - Workstation
 Description:
 The FAT filesystem format is primarily used on older windows systems and portable USB
-drives or flash modules. It comes in three types FAT12, FAT16, and FAT32 all of which are
+drives or flash modules. It comes in three typesFAT12 ,FAT16 , andFAT32 all of which are
 supported by the vfat kernel module.
 Rationale:
 Removing support for unneeded filesystem types reduces the local attack surface of the
@@ -193,7 +193,7 @@ install /bin/true
 # lsmod | grep vfat
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fi/etc/modprobe.d/CIS.conf   and add the following line:
 install vfat /bin/true
 Impact:
 FAT filesystems are often used on portable USB sticks and other flash media are commonly
@@ -209,20 +209,20 @@ The /tmp directory is a world-writable directory used for temporary storage by a
 and some applications.
 Rationale:
 Since the /tmp directory is intended to be world-writable, there is a risk of resource
-exhaustion if it is not bound to a separate partition. In addition, making /tmp its own file
+exhaustion if it is not bound to a separate partition. In addition, mak/tmp its own file
 system allows an administrator to set the noexec option on the mount, making /tmp
 useless for an attacker to install executable code. It would also prevent an attacker from
-establishing a hardlink to a system setuid program and wait for it to be updated. Once the
+establishing a hardlink to a systemsetuid program and wait for it to be updated. Once the
 program was updated, the hardlink would be broken and the attacker would have his own
 copy of the program. If the program happened to have a security vulnerability, the attacker
 could continue to exploit the known flaw.
 Audit:
-Run the following command and verify output shows /tmp is mounted:
+Run the following command and verify output shows  /tmp is mounted:
 # mount | grep /tmp
 tmpfs on /tmp type tmpfs (rw,nosuid,nodev,noexec,relatime)
 Remediation:
 For new installations, during installation create a custom partition setup and specify a
-separate partition for /tmp.
+separate partition for/tmp .
 For systems that were previously installed, create a new partition and configure
 /etc/fstab as appropriate.
 Impact:
@@ -235,7 +235,7 @@ References:
 1. AJ Lewis, "LVM HOWTO", http://tldp.org/HOWTO/LVM-HOWTO/
 Notes:
 systemd includes the tmp.mount service which should be used instead of
-configuring /etc/fstab.
+configuring /etc/fstab .
 
 
 
@@ -245,45 +245,45 @@ Description:
 The nodev mount option specifies that the filesystem cannot contain special devices.
 Rationale:
 Since the /tmp filesystem is not intended to support devices, set this option to ensure that
-users cannot attempt to create block or character special devices in /tmp.
+users cannot attempt to create block or character special devices i/tmp .
 Audit:
-If a /tmp partition exists run the following command and verify that the nodev option is set
+If a/tmp partition exists run the following command and verify that thenodev option is set
 on /tmp:
 # mount | grep /tmp
 tmpfs on /tmp type tmpfs (rw,nosuid,nodev,noexec,relatime)
 Remediation:
-Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for
-the /tmp partition. See the fstab(5) manual page for more information.
-Run the following command to remount /tmp:
+Edit the/etc/fstab  file and addnodev to the fourth field (mounting options) for
+the /tmp partition. See thfstab(5)  manual page for more information.
+Run the following command to remount  /tmp :
 # mount -o remount,nodev /tmp
 Notes:
 systemd includes the tmp.mount service which should be used instead of
-configuring /etc/fstab. Mounting options are configured in the Options setting
-in /etc/systemd/system/tmp.mount.
+configuring /etc/fstab . Mounting options are configured in the Options setting
+in/etc/systemd/system/tmp.mount   .
 
 
 
 1.1.4 Ensure nosuid option set on /tmp partition (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The nosuid mount option specifies that the filesystem cannot contain setuid files.
+The nosuid  mount option specifies that the filesystem cannot contain setuid files.
 Rationale:
 Since the /tmp filesystem is only intended for temporary file storage, set this option to
-ensure that users cannot create setuid files in /tmp.
+ensure that users cannot create setuid files i/tmp .
 Audit:
-If a /tmp partition exists run the following command and verify that the nosuid option is set
+If a/tmp partition exists run the following command and verify that the nosuid option is set
 on /tmp:
 # mount | grep /tmp
 tmpfs on /tmp type tmpfs (rw,nosuid,nodev,noexec,relatime)
 Remediation:
-Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for
-the /tmp partition. See the fstab(5) manual page for more information.
-Run the following command to remount /tmp:
+Edit the/etc/fstab  file and addnosuid to the fourth field (mounting options) for
+the /tmp partition. See thefstab(5) manual page for more information.
+Run the following command to remount   /tmp:
 # mount -o remount,nosuid /tmp
 Notes:
 systemd includes the tmp.mount service which should be used instead of
-configuring /etc/fstab. Mounting options are configured in the Options setting
-in /etc/systemd/system/tmp.mount.
+configuring /etc/fstab . Mounting options are configured in the Options setting
+in/etc/systemd/system/tmp.mount   .
 
 
 
@@ -296,12 +296,12 @@ Rationale:
 Since the /var directory may contain world-writable files and directories, there is a risk of
 resource exhaustion if it is not bound to a separate partition.
 Audit:
-Run the following command and verify output shows /var is mounted:
+Run the following command and verify output shows  /var is mounted:
 # mount | grep /var
 /dev/xvdg1 on /var type ext4 (rw,relatime,data=ordered)
 Remediation:
 For new installations, during installation create a custom partition setup and specify a
-separate partition for /var.
+separate partition for/var .
 For systems that were previously installed, create a new partition and
 configure /etc/fstab as appropriate.
 Impact:
@@ -317,24 +317,24 @@ References:
 1.1.6 Ensure separate partition exists for /var/tmp (Scored)
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
-The /var/tmp directory is a world-writable directory used for temporary storage by all
+The /var/tmp  directory is a world-writable directory used for temporary storage by all
 users and some applications.
 Rationale:
 Since the /var/tmp directory is intended to be world-writable, there is a risk of resource
-exhaustion if it is not bound to a separate partition. In addition, making /var/tmp its own
-file system allows an administrator to set the noexec option on the mount,
+exhaustion if it is not bound to a separate partition. In addition, maki/var/tmp its own
+file system allows an administrator to set thnoexec option on the mount,
 making /var/tmp useless for an attacker to install executable code. It would also prevent
-an attacker from establishing a hardlink to a system setuid program and wait for it to be
+an attacker from establishing a hardlink to a systemsetuid program and wait for it to be
 updated. Once the program was updated, the hardlink would be broken and the attacker
 would have his own copy of the program. If the program happened to have a security
 vulnerability, the attacker could continue to exploit the known flaw.
 Audit:
-Run the following command and verify output shows /var/tmp is mounted:
+Run the following command and verify output shows  /var/tmp is mounted:
 # mount | grep /var/tmp
 tmpfs on /var/tmp type ext4 (rw,nosuid,nodev,noexec,relatime)
 Remediation:
 For new installations, during installation create a custom partition setup and specify a
-separate partition for /var/tmp.
+separate partition for/var/tmp .
 For systems that were previously installed, create a new partition and
 configure /etc/fstab as appropriate.
 Impact:
@@ -348,19 +348,19 @@ introduce their own security considerations.
 1.1.7 Ensure nodev option set on /var/tmp partition (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The nodev mount option specifies that the filesystem cannot contain special devices.
+The nodev  mount option specifies that the filesystem cannot contain special devices.
 Rationale:
 Since the /var/tmp filesystem is not intended to support devices, set this option to ensure
-that users cannot attempt to create block or character special devices in /var/tmp.
+that users cannot attempt to create block or character special devices in/var/tmp .
 Audit:
-If a /var/tmp partition exists run the following command and verify that the nodev option is
-set on /var/tmp.
+If a/var/tmp partition exists run the following command and verify that the nodev option is
+set on /var/tmp .
 # mount | grep /var/tmp
 tmpfs on /var/tmp type tmpfs (rw,nosuid,nodev,noexec,relatime)
 Remediation:
-Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for
-the /var/tmp partition. See the fstab(5) manual page for more information.
-Run the following command to remount /var/tmp:
+Edit the/etc/fstab  file and addnodev to the fourth field (mounting options) for
+the /var/tmp partition. See thefstab(5) manual page for more information.
+Run the following command to remount   /var/tmp :
 # mount -o remount,nodev /var/tmp
 
 
@@ -368,19 +368,19 @@ Run the following command to remount /var/tmp:
 1.1.8 Ensure nosuid option set on /var/tmp partition (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The nosuid mount option specifies that the filesystem cannot contain setuid files.
+The nosuid  mount option specifies that the filesystem cannot contain setuid files.
 Rationale:
 Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
-ensure that users cannot create setuid files in /var/tmp.
+ensure that users cannot create setuid files i/var/tmp .
 Audit:
-If a /var/tmp partition exists run the following command and verify that the nosuid option
-is set on /var/tmp.
+If a/var/tmp partition exists run the following command and verify that the nosuid option
+is set on/var/tmp .
 # mount | grep /var/tmp
 tmpfs on /var/tmp type tmpfs (rw,nosuid,nodev,noexec,relatime)
 Remediation:
-Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for
-the /var/tmp partition. See the fstab(5) manual page for more information.
-Run the following command to remount /var/tmp:
+Edit the/etc/fstab  file and addnosuid to the fourth field (mounting options) for
+the /var/tmp partition. See thefstab(5) manual page for more information.
+Run the following command to remount   /var/tmp :
 # mount -o remount,nosuid /var/tmp
 
 
@@ -388,19 +388,19 @@ Run the following command to remount /var/tmp:
 1.1.9 Ensure noexec option set on /var/tmp partition (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The noexec mount option specifies that the filesystem cannot contain executable binaries.
+The noexec  mount option specifies that the filesystem cannot contain executable binaries.
 Rationale:
 Since the /var/tmp filesystem is only intended for temporary file storage, set this option to
-ensure that users cannot run executable binaries from /var/tmp.
+ensure that users cannot run executable binaries from /var/tmp .
 Audit:
-If a /var/tmp partition exists run the following command and verify that the noexec option
-is set on /var/tmp.
+If a/var/tmp partition exists run the following command and verify that the noexec option
+is set on/var/tmp .
 # mount | grep /var/tmp
 tmpfs on /var/tmp type tmpfs (rw,nosuid,nodev,noexec,relatime)
 Remediation:
-Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for the
-/var/tmp partition. See the fstab(5) manual page for more information.
-Run the following command to remount /var/tmp:
+Edit the/etc/fstab  file and addnoexec to the fourth field (mounting options) for the
+/var/tmp partition. See thefstab(5) manual page for more information.
+Run the following command to remount   /var/tmp :
 # mount -o remount,noexec /var/tmp
 
 
@@ -414,12 +414,12 @@ There are two important reasons to ensure that system logs are stored on a separ
 partition: protection against resource exhaustion (since logs can grow quite large) and
 protection of audit data.
 Audit:
-Run the following command and verify output shows /var/log is mounted:
+Run the following command and verify output shows  /var/log is mounted:
 # mount | grep /var/log
 /dev/xvdh1 on /var/log type ext4 (rw,relatime,data=ordered)
 Remediation:
 For new installations, during installation create a custom partition setup and specify a
-separate partition for /var/log.
+separate partition for/var/log .
 For systems that were previously installed, create a new partition and
 configure /etc/fstab as appropriate.
 Impact:
@@ -435,20 +435,20 @@ References:
 1.1.11 Ensure separate partition exists for /var/log/audit (Scored)
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
-The auditing daemon, auditd, stores log data in the /var/log/audit directory.
+The auditing daemon, auditd , stores log data in t/var/log/audit  directory.
 Rationale:
 There are two important reasons to ensure that data gathered by auditd is stored on a
-separate partition: protection against resource exhaustion (since the audit.log file can
+separate partition: protection against resource exhaustion (since theaudit.log file can
 grow quite large) and protection of audit data. The audit daemon calculates how much free
-space is left and performs actions based on the results. If other processes (such as syslog)
-consume space in the same partition as auditd, it may not perform as desired.
+space is left and performs actions based on the results. If other processes (such syslog )
+consume space in the same partition as auditd , it may not perform as desired.
 Audit:
-Run the following command and verify output shows /var/log/audit is mounted:
+Run the following command and verify output shows  /var/log/audit  is mounted:
 # mount | grep /var/log/audit
 /dev/xvdi1 on /var/log/audit type ext4 (rw,relatime,data=ordered)
 Remediation:
 For new installations, during installation create a custom partition setup and specify a
-separate partition for /var/log/audit.
+separate partition for/var/log/audit .
 For systems that were previously installed, create a new partition and
 configure /etc/fstab as appropriate.
 Impact:
@@ -466,16 +466,16 @@ Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
 The /home directory is used to support disk storage needs of local users.
 Rationale:
-If the system is intended to support local users, create a separate partition for the /home
+If the system is intended to support local users, create a separate partition for /home
 directory to protect against resource exhaustion and restrict the type of files that can be
 stored under /home.
 Audit:
-Run the following command and verify output shows /home is mounted:
+Run the following command and verify output shows   /home is mounted:
 # mount | grep /home
 /dev/xvdf1 on /home type ext4 (rw,nodev,relatime,data=ordered)
 Remediation:
 For new installations, during installation create a custom partition setup and specify a
-separate partition for /home.
+separate partition for/home .
 For systems that were previously installed, create a new partition and
 configure /etc/fstab as appropriate.
 Impact:
@@ -496,13 +496,13 @@ Rationale:
 Since the user partitions are not intended to support devices, set this option to ensure that
 users cannot attempt to create block or character special devices.
 Audit:
-If a /home partition exists run the following command and verify that the nodev option is set
-on /home.
+If a/home partition exists run the following command and verify that thenodev option is set
+on /home .
 # mount | grep /home
 /dev/xvdf1 on /home type ext4 (rw,nodev,relatime,data=ordered)
 Remediation:
-Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for the
-/home partition. See the fstab(5) manual page for more information.
+Edit the/etc/fstab  file and addnodev to the fourth field (mounting options) for the
+/home partition. See thefstab(5) manual page for more information.
 # mount -o remount,nodev /home
 Notes:
 The actions in this recommendation refer to the /home partition, which is the default user
@@ -518,15 +518,15 @@ Description:
 The nodev mount option specifies that the filesystem cannot contain special devices.
 Rationale:
 Since the /run/shm filesystem is not intended to support devices, set this option to ensure
-that users cannot attempt to create special devices in /dev/shm partitions.
+that users cannot attempt to create special devices i/dev/shm  partitions.
 Audit:
-Run the following command and verify that the nodev option is set on /dev/shm.
+Run the following command and verify that the nodev option is set o/dev/shm .
 # mount | grep /dev/shm
 tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime)
 Remediation:
-Edit the /etc/fstab file and add nodev to the fourth field (mounting options) for
-the /dev/shm partition. See the fstab(5) manual page for more information.
-Run the following command to remount /dev/shm:
+Edit the/etc/fstab  file and addnodev to the fourth field (mounting options) for
+the /dev/shm partition. See thfstab(5)  manual page for more information.
+Run the following command to remount  /dev/shm :
 # mount -o remount,nodev /dev/shm
 
 
@@ -539,13 +539,12 @@ Rationale:
 Setting this option on a file system prevents users from introducing privileged programs
 onto the system and allowing non-root users to execute them.
 Audit:
-Run the following command and verify that the nosuid option is set on /dev/shm.
-# mount | grep /dev/shm
+Run the following command and verify that the no suid option is set on/dev/shm .
 tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime)
 Remediation:
-Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) for
-the /dev/shm partition. See the fstab(5) manual page for more information.
-Run the following command to remount /dev/shm:
+Edit the/etc/fstab  file and addnosuid to the fourth field (mounting options) for
+the /dev/shm partition. See thfstab(5)  manual page for more information.
+Run the following command to remount  /dev/shm :
 # mount -o remount,nosuid /dev/shm
 
 
@@ -558,13 +557,12 @@ Rationale:
 Setting this option on a file system prevents users from executing programs from shared
 memory. This deters users from introducing potentially malicious software on the system.
 Audit:
-Run the following command and verify that the noexec option is set on /run/shm.
-# mount | grep /dev/shm
+Run the following command and verify that the noexec option is set on/run/shm .
 tmpfs on /dev/shm type tmpfs (rw,nosuid,nodev,noexec,relatime)
 Remediation:
-Edit the /etc/fstab file and add noexec to the fourth field (mounting options) for
-the /dev/shm partition. See the fstab(5) manual page for more information.
-Run the following command to remount /dev/shm:
+Edit the/etc/fstab  file and addnoexec to the fourth field (mounting options) for
+the /dev/shm partition. See thfstab(5)  manual page for more information.
+Run the following command to remount  /dev/shm :
 # mount -o remount,noexec /dev/shm
 
 
@@ -583,9 +581,9 @@ Run the following command and verify that the nodev option is set on all removab
 partitions.
 # mount
 Remediation:
-Edit the /etc/fstab file and add nodev to the fourth field (mounting options) of all
+Edit the/etc/fstab  file and adnodev to the fourth field (mounting options) of all
 removable media partitions. Look for entries that have mount points that contain words
-such as floppy or cdrom. See the fstab(5) manual page for more information.
+such as floppy or cdrom. See thefstab(5) manual page for more information.
 
 
 
@@ -593,7 +591,7 @@ such as floppy or cdrom. See the fstab(5) manual page for more information.
 Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The nosuid mount option specifies that the filesystem cannot contain setuid files.
+The nosuid mount option specifies that the filesystem cannot containsetuid files.
 Rationale:
 Setting this option on a file system prevents users from introducing privileged programs
 onto the system and allowing non-root users to execute them.
@@ -602,9 +600,9 @@ Run the following command and verify that the nosuid option is set on all remova
 partitions.
 # mount
 Remediation:
-Edit the /etc/fstab file and add nosuid to the fourth field (mounting options) of all
+Edit the/etc/fstab  file and addnosuid to the fourth field (mounting options) of all
 removable media partitions. Look for entries that have mount points that contain words
-such as floppy or cdrom. See the fstab(5) manual page for more information.
+such as floppy or cdrom. See thefstab(5) manual page for more information.
 
 
 
@@ -622,9 +620,9 @@ Run the following command and verify that the noexec option is set on all remova
 partitions.
 # mount
 Remediation:
-Edit the /etc/fstab file and add noexec to the fourth field (mounting options) of all
+Edit the/etc/fstab  file and adnoexec to the fourth field (mounting options) of all
 removable media partitions. Look for entries that have mount points that contain words
-such as floppy or cdrom. See the fstab(5) manual page for more information.
+such as floppy or cdrom. See thefstab(5) manual page for more information.
 
 
 
@@ -644,8 +642,7 @@ bit set:
 No output should be returned.
 Remediation:
 Run the following command to set the sticky bit on all world writable directories:
-# df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type d
--perm -0002 2>/dev/null | chmod a+t
+-perm -0002 2>/dev/null | chmod a+tprint $6'} | xargs -I '{}' find '{}' -xdev -type d
 
 
 
@@ -658,12 +655,12 @@ With automounting enabled anyone with physical access could attach a USB drive o
 and have its contents available in system even if they lacked permissions to mount it
 themselves.
 Audit:
-Run the following command to verify autofs is not enabled:
+Run the following command to verify autofs  is not enabled:
 # systemctl is-enabled autofs
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable autofs:
+Run the following command to disable  autofs :
 # systemctl disable autofs
 Impact:
 The use portable hard drives is very common for workstation users. If your organization
@@ -752,7 +749,7 @@ References:
 1. AIDE stable manual: http://aide.sourceforge.net/stable/manual.html
 Notes:
 The prelinking feature can interfere with AIDE because it alters binaries to speed up their
-start up times. Run prelink -ua to restore the binaries to their prelinked state, thus
+start up times. Run prelink -ua  to restore the binaries to their prelinked state, thus
 avoiding false positives from AIDE.
 
 
@@ -767,7 +764,6 @@ critical files have been changed in an unauthorized fashion.
 Audit:
 Run the following commands to determine if there is a cron job scheduled to run the aide
 check.
-# crontab -u root -l | grep aide
 # grep -r aide /etc/cron.* /etc/crontab
 Ensure a cron job in compliance with site policy is returned.
 Remediation:
@@ -787,7 +783,7 @@ involved in the boot process directly.
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 The grub configuration file contains information on boot settings and passwords for
-unlocking boot options. The grub configuration is usually grub.cfg stored in /boot/grub.
+unlocking boot options. The grub configuration is usuallgrub.cfg stored in/boot/grub.
 Rationale:
 Setting the permissions to read and write for root only prevents non-root users from
 seeing the boot parameters or changing them. Non-root users who read the boot
@@ -795,14 +791,9 @@ parameters may be able to identify weaknesses in security upon boot and be able 
 them.
 Audit:
 Run the following command and verify Uid and Gid are both 0/root and Access does not
-grant permissions to group or other:
+grant permissions to group orother :
 # stat /boot/grub/grub.cfg
-Access: (0600/-rw-------) Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------)  Uid: (  0/  root)  Gid: (  0/   root)
 Remediation:
 Run the following commands to set permissions on your grub configuration:
 # chown root:root /boot/grub/grub.cfg
@@ -824,22 +815,21 @@ user from entering boot parameters or changing the boot partition. This prevents
 from weakening security (e.g. turning off SELinux at boot time).
 Audit:
 Run the following commands and verify output matches:
-# grep "^set superusers" /boot/grub/grub.cfg
-set superusers="<username>"
+set superusers="<username>"oot/grub/grub.cfg
 # grep "^password" /boot/grub/grub.cfg
 password_pbkdf2 <username> <encrypted-password>
 Remediation:
-Create an encrypted password with grub-mkpasswd-pbkdf2:
+Create an encrypted password with  grub-mkpasswd-pbkdf2  :
 # grub-mkpasswd-pbkdf2
 Enter password: <password>
 Reenter password: <password>
 Your PBKDF2 is <encrypted-password>
-Add the following into /etc/grub.d/00_header or a custom /etc/grub.d configuration file:
+Add the following into/etc/grub.d/00_header  or a custom /etc/grub.d  configuration file:
 cat <<EOF
 set superusers="<username>"
 password_pbkdf2 <username> <encrypted-password>
 EOF
-Run the following command to update the grub2 configuration:
+Run the following command to update the  grub2 configuration:
 # update-grub
 Notes:
 
@@ -857,11 +847,11 @@ Rationale:
 Requiring authentication in single user mode prevents an unauthorized user from
 rebooting the system into single user to gain root privileges without credentials.
 Audit:
-Perform the following to determine if a password is set for the root user:
+Perform the following to determine if a password is set for throot user:
 # grep ^root:[*\!]: /etc/shadow
 No results should be returned.
 Remediation:
-Run the following command and follow the prompts to set a password for the root user:
+Run the following command and follow the prompts to set a password for the  root user:
 # passwd root
 
 
@@ -877,8 +867,8 @@ file. The system provides the ability to set a soft limit for core dumps, but th
 overridden by the user.
 Rationale:
 Setting a hard limit on core dumps prevents users from overriding the soft variable. If core
-dumps are required, consider setting limits for user groups (see limits.conf(5)). In
-addition, setting the fs.suid_dumpable variable to 0 will prevent setuid programs from
+dumps are required, consider setting limits for user groups (seelimits.conf(5)  ). In
+addition, setting thefs.suid_dumpable  variable to 0 will prevent setuid programs from
 dumping core.
 Audit:
 Run the following commands and verify output matches:
@@ -887,10 +877,10 @@ Run the following commands and verify output matches:
 # sysctl fs.suid_dumpable
 fs.suid_dumpable = 0
 Remediation:
-Add the following line to the /etc/security/limits.conf file or a
-/etc/security/limits.d/* file:
+Add the following line to the/etc/security/limits.conf   file or a
+/etc/security/limits.d/*   file:
 * hard core 0
-Set the following parameter in the /etc/sysctl.conf file:
+Set the following parameter in the /etc/sysctl.conf  file:
 fs.suid_dumpable = 0
 Run the following command to set the active kernel parameter:
 
@@ -943,7 +933,7 @@ Run the following command and verify output matches:
 # sysctl kernel.randomize_va_space
 kernel.randomize_va_space = 2
 Remediation:
-Set the following parameter in the /etc/sysctl.conf file:
+Set the following parameter in the/etc/sysctl.conf  file:
 kernel.randomize_va_space = 2
 Run the following command to set the active kernel parameter:
 # sysctl -w kernel.randomize_va_space=2
@@ -953,21 +943,20 @@ Run the following command to set the active kernel parameter:
 1.5.4 Ensure prelink is disabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-is a program that modifies ELF shared libraries and ELF dynamically linked
+prelink is a program that modifies ELF shared libraries and ELF dynamically linked
 binaries in such a way that the time needed for the dynamic linker to perform relocations
 at startup significantly decreases.
-prelink
 Rationale:
 The prelinking feature can interfere with the operation of AIDE, because it changes
 binaries. Prelinking can also increase the vulnerability of the system if a malicious user is
 able to compromise a common library such as libc.
 Audit:
-Run the following command and verify prelink is not installed:
+Run the following command and verify  prelink is not installed:
 # dpkg -s prelink
 Remediation:
 Run the following command to restore binaries to normal:
 # prelink -ua
-Run the following command to uninstall prelink:
+Run the following command to uninstall prelink :
 # apt-get remove prelink
 1.6 Mandatory Access Control
 Mandatory Access Control (MAC) provides an additional layer of access restrictions to
@@ -994,16 +983,11 @@ must be satisfied as well as the SELinux MAC rules. The action will not be allow
 one of these models does not permit the action. In this way, SELinux rules can only make a
 system's permissions more restrictive and secure. SELinux requires a complex policy to
 allow all the actions required of a system under normal operation. Three such policies have
-been available for use with Ubuntu and are included with the system: ubuntu, default,
-strict, and mls. These are described as follows: 
-ubuntu: targeted rules developed for ubuntu specifically
-default: targeted rules developed and maintained by Debian.
-Consists mostly of
+been available for use with Ubuntu and are included with the system:  ubuntu ,default ,
+strict , and mls. These are described as follows:  ubuntu : targeted rules developed for ubuntu specifically  default : targeted rules developed and maintained by Debian. Consists mostly of
 Type Enforcement (TE) rules, and a small number of Role-Based Access Control
 (RBAC) rules. Targeted restricts the actions of many types of programs, but leaves
-interactive users largely unaffected.
-strict: also uses TE and RBAC rules, but on more programs and more aggressively.
-mls: implements Multi-Level Security (MLS), which introduces even more kinds of
+interactive users largely unaffected.  strict : also uses TE and RBAC rules, but on more programs and more aggressively.  mls : implements Multi-Level Security (MLS), which introduces even more kinds of
 labels (sensitivity and category) and rules that govern access based on these.
 This section provides guidance for the configuration of the targeted policy.
 Note: This section only applies if SELinux is in use on the system. Recommendations for
@@ -1017,7 +1001,8 @@ References:
 1. FAQ: http://docs.fedoraproject.org/selinux-faq
 2. User Guide: http://docs.fedoraproject.org/selinux-user-guide
 
-3. Managing Services Guide: http://docs.fedoraproject.org/selinux-managingconfined-services-guide
+3. Managing Services Guide: http://docs.fedoraproject.org/selinux-managing-
+confined-services-guide
 3. SELinux Project web page and wiki:
 1. http://www.selinuxproject.org
 4. Chapters 43-45 of Red Hat Enterprise Linux 5: Deployment Guide (Frank Mayer,
@@ -1034,11 +1019,11 @@ Rationale:
 SELinux must be enabled at boot time in your grub configuration to ensure that the
 controls it provides are not overridden.
 Audit:
-Run the following command and verify that no linux line has the selinux=0 or enforcing=0
+Run the following command and verify that no linux line has theselinux=0 or enforcing=0
 parameters set:
 # grep "^\s*linux" /boot/grub/grub.cfg
 Remediation:
-Edit /etc/default/grub and remove all instances of selinux=0 and enforcing=0 from all
+Edit/etc/default/grub  and remove all instances ofselinux=0 and enforcing=0 from all
 CMDLINE_LINUX parameters:
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
 GRUB_CMDLINE_LINUX=""
@@ -1060,14 +1045,13 @@ SELinux must be enabled at boot time in to ensure that the controls it provides 
 at all times.
 Audit:
 Run the following commands and ensure output matches:
-# grep SELINUX=enforcing /etc/selinux/config
-SELINUX=enforcing
+SELINUX=enforcingforcing /etc/selinux/config
 # sestatus
 SELinux status: enabled
 Current mode: enforcing
 Mode from config file: enforcing
 Remediation:
-Edit the /etc/selinux/config file to set the SELINUX parameter:
+Edit the/etc/selinux/config   file to set the SELINUX parameter:
 SELINUX=enforcing
 
 
@@ -1082,17 +1066,16 @@ Security configuration requirements vary from site to site. Some sites may manda
 policy that is stricter than the default policy, which is perfectly acceptable. This item is
 intended to ensure that at least the default recommendations are met.
 Audit:
-Run the following commands and ensure output matches "ubuntu", "default" or "mls":
+Run the following commands and ensure output matches "   ubuntu ", default " or "mls":
 # grep SELINUXTYPE= /etc/selinux/config
 SELINUXTYPE=ubuntu
-# sestatus
 Policy from config file: ubuntu
 Remediation:
-Edit the /etc/selinux/config file to set the SELINUXTYPE parameter:
+Edit the/etc/selinux/config   file to set the SELINUXTYPE parameter:
 SELINUXTYPE=ubuntu
 Notes:
 If your organization requires stricter policies, ensure that they are set in
-the /etc/selinux/config file.
+the /etc/selinux/config   file.
 
 
 
@@ -1102,8 +1085,8 @@ Description:
 Daemons that are not defined in SELinux policy will inherit the security context of their
 parent process.
 Rationale:
-Since daemons are launched and descend from the init process, they will inherit the
-security context label initrc_t. This could cause the unintended consequence of giving the
+Since daemons are launched and descend from the  init process, they will inherit the
+security context labelinitrc_t . This could cause the unintended consequence of giving the
 process more permission than it requires.
 Audit:
 Run the following command and verify not output is produced:
@@ -1150,14 +1133,14 @@ Rationale:
 AppArmor must be enabled at boot time in your bootloader configuration to ensure that
 the controls it provides are not overridden.
 Audit:
-Run the following command and verify that no linux line the apparmor=0 parameter set:
+Run the following command and verify that no linux line theapparmor=0 parameter set:
 # grep "^\s*linux" /boot/grub/grub.cfg
 Remediation:
-Edit /etc/default/grub and remove all instances of apparmor=0 from all CMDLINE_LINUX
+Edit /etc/default/grub  and remove all instances ofapparmor=0 from all CMDLINE_LINUX
 parameters:
 GRUB_CMDLINE_LINUX_DEFAULT="quiet"
 GRUB_CMDLINE_LINUX=""
-Run the following command to update the grub2 configuration:
+Run the following command to update the  grub2 configuration:
 # update-grub
 Notes:
 This recommendation is designed around the grub bootloader, if LILO or another
@@ -1225,7 +1208,6 @@ Run the following commands and verify either SELinux or AppArmor is installed:
 # dpkg -s apparmor
 Remediation:
 Run one of the following commands to install SELinux or apparmor:
-# apt-get install selinux
 # apt-get install apparmor
 1.7 Warning Banners
 Presenting a warning message prior to the normal user login may assist in the prosecution
@@ -1246,17 +1228,17 @@ example only. Please edit to include the specific text for your organization as 
 your legal department.
 
 1.7.1 Command Line Warning Banners
-The /etc/motd, /etc/issue, and /etc/issue.net files govern warning banners for
+The /etc/motd ,/etc/issue , and/etc/issue.net  files govern warning banners for
 standard command line logins for both local and remote users.
 
 1.7.1.1 Ensure message of the day is configured properly (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The contents of the /etc/motd file are displayed to users after login and function as a
+The contents of the/etc/motd file are displayed to users after login and function as a
 message of the day for authenticated users.
 Unix-based systems have typically displayed information about the OS release and patch
 level upon logging in to the system. This information can be useful to developers who are
-developing software for a particular OS platform. If mingetty(8) supports the following
+developing software for a particular OS platform. Imingetty(8)  supports the following
 options, they display operating system information:
 \m - machine architecture
 \r - operating system release
@@ -1268,7 +1250,7 @@ status regarding the system and must include the name of the organization that o
 system and any monitoring policies that are in place. Displaying OS and patch level
 information in login banners also has the side effect of providing detailed system
 information to attackers attempting to target specific exploits of a system. Authorized users
-can easily get this information by running the "uname -a" command once they have logged
+can easily get this information by running theuname -a " command once they have logged
 in.
 Audit:
 Run the following command and verify that the contents match site policy:
@@ -1278,7 +1260,7 @@ Run the following command and verify no results are returned:
 # egrep '(\\v|\\r|\\m|\\s)' /etc/motd
 Remediation:
 Edit the /etc/motd file with the appropriate contents according to your site policy, remove
-any instances of \m, \r, \s, or \v.
+any instances of \m ,\r,\s , or\v.
 
 
 
@@ -1286,10 +1268,10 @@ any instances of \m, \r, \s, or \v.
 Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The contents of the /etc/issue file are displayed to users prior to login for local terminals.
+The contents of the/etc/issue  file are displayed to users prior to login for local terminals.
 Unix-based systems have typically displayed information about the OS release and patch
 level upon logging in to the system. This information can be useful to developers who are
-developing software for a particular OS platform. If mingetty(8) supports the following
+developing software for a particular OS platform. Imingetty(8)  supports the following
 options, they display operating system information:
 \m - machine architecture
 \r - operating system release
@@ -1301,7 +1283,7 @@ status regarding the system and must include the name of the organization that o
 system and any monitoring policies that are in place. Displaying OS and patch level
 information in login banners also has the side effect of providing detailed system
 information to attackers attempting to target specific exploits of a system. Authorized users
-can easily get this information by running the "uname -a" command once they have logged
+can easily get this information by running theuname -a " command once they have logged
 in.
 Audit:
 Run the following command and verify that the contents match site policy:
@@ -1310,8 +1292,8 @@ Run the following command and verify no results are returned:
 
 # egrep '(\\v|\\r|\\m|\\s)' /etc/issue
 Remediation:
-Edit the /etc/issue file with the appropriate contents according to your site policy,
-remove any instances of \m, \r, \s, or \v:
+Edit the /etc/issue  file with the appropriate contents according to your site policy,
+remove any instances of  \m,\r ,\s, or\v :
 # echo "Authorized uses only. All activity may be monitored and reported." >
 /etc/issue
 
@@ -1321,11 +1303,11 @@ remove any instances of \m, \r, \s, or \v:
 Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The contents of the /etc/issue.net file are displayed to users prior to login for remote
+The contents of the/etc/issue.net  file are displayed to users prior to login for remote
 connections from configured services.
 Unix-based systems have typically displayed information about the OS release and patch
 level upon logging in to the system. This information can be useful to developers who are
-developing software for a particular OS platform. If mingetty(8) supports the following
+developing software for a particular OS platform. Imingetty(8)  supports the following
 options, they display operating system information:
 \m - machine architecture
 \r - operating system release
@@ -1337,7 +1319,7 @@ status regarding the system and must include the name of the organization that o
 system and any monitoring policies that are in place. Displaying OS and patch level
 information in login banners also has the side effect of providing detailed system
 information to attackers attempting to target specific exploits of a system. Authorized users
-can easily get this information by running the "uname -a" command once they have logged
+can easily get this information by running theuname -a " command once they have logged
 in.
 Audit:
 Run the following command and verify that the contents match site policy:
@@ -1346,8 +1328,8 @@ Run the following command and verify no results are returned:
 # egrep '(\\v|\\r|\\m|\\s)' /etc/issue.net
 
 Remediation:
-Edit the /etc/issue.net file with the appropriate contents according to your site policy,
-remove any instances of \m, \r, \s, or \v:
+Edit the /etc/issue.net  file with the appropriate contents according to your site policy,
+remove any instances of  \m,\r ,\s, or\v :
 # echo "Authorized uses only. All activity may be monitored and reported." >
 /etc/issue.net
 
@@ -1356,23 +1338,17 @@ remove any instances of \m, \r, \s, or \v:
 1.7.1.4 Ensure permissions on /etc/motd are configured (Not Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The contents of the /etc/motd file are displayed to users after login and function as a
+The contents of the/etc/motd file are displayed to users after login and function as a
 message of the day for authenticated users.
 Rationale:
-If the /etc/motd file does not have the correct ownership it could be modified by
+If the/etc/motd file does not have the correct ownership it could be modified by
 unauthorized users with incorrect or misleading information.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 644:
+Run the following command and verify  Uid and Gid are both 0/root and Access is644 :
 # stat /etc/motd
-Access: (0644/-rw-r--r--)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0644/-rw-r--r--)  Uid: (   0/  root)  Gid: (   0/  root)
 Remediation:
-Run the following commands to set permissions on /etc/motd:
+Run the following commands to set permissions on  /etc/motd :
 # chown root:root /etc/motd
 # chmod 644 /etc/motd
 
@@ -1381,22 +1357,15 @@ Run the following commands to set permissions on /etc/motd:
 1.7.1.5 Ensure permissions on /etc/issue are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The contents of the /etc/issue file are displayed to users prior to login for local terminals.
+The contents of the/etc/issue  file are displayed to users prior to login for local terminals.
 Rationale:
-If the /etc/issue file does not have the correct ownership it could be modified by
+If the/etc/issue file does not have the correct ownership it could be modified by
 unauthorized users with incorrect or misleading information.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 644:
-# stat /etc/issue
-Access: (0644/-rw-r--r--)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Run the following command and verify  Uid and Gid are both 0/root and Access is644 :
+Access: (0644/-rw-r--r--)  Uid: (   0/  root)  Gid: (   0/  root)
 Remediation:
-Run the following commands to set permissions on /etc/issue:
+Run the following commands to set permissions on  /etc/issue :
 # chown root:root /etc/issue
 # chmod 644 /etc/issue
 
@@ -1405,23 +1374,17 @@ Run the following commands to set permissions on /etc/issue:
 1.7.1.6 Ensure permissions on /etc/issue.net are configured (Not Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The contents of the /etc/issue.net file are displayed to users prior to login for remote
+The contents of the/etc/issue.net  file are displayed to users prior to login for remote
 connections from configured services.
 Rationale:
-If the /etc/issue.net file does not have the correct ownership it could be modified by
+If the/etc/issue.net file does not have the correct ownership it could be modified by
 unauthorized users with incorrect or misleading information.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 644:
+Run the following command and verify  Uid and Gid are both 0/root and Access is644 :
 # stat /etc/issue.net
-Access: (0644/-rw-r--r--)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0644/-rw-r--r--)  Uid: (   0/  root)  Gid: (   0/  root)
 Remediation:
-Run the following commands to set permissions on /etc/issue.net:
+Run the following commands to set permissions on  /etc/issue.net :
 # chown root:root /etc/issue.net
 # chmod 644 /etc/issue.net
 
@@ -1437,23 +1400,23 @@ Warning messages inform users who are attempting to login to the system of their
 status regarding the system and must include the name of the organization that owns the
 system and any monitoring policies that are in place.
 Audit:
-If GDM is installed on the system verify that /etc/dconf/profile/gdm exists and contains
+If GDM is installed on the system verify th/etc/dconf/profile/gdm  exists and contains
 the following:
 user-db:user
 system-db:gdm
 file-db:/usr/share/gdm/greeter-dconf-defaults
-Then verify the banner-message-enable and banner-message-text options are configured
-in /etc/dconf/db/gdm.d/01-banner-message:
+Then verify the banner-message-enable  and banner-message-text  options are configured
+in/etc/dconf/db/gdm.d/01-banner-message   :
 [org/gnome/login-screen]
 banner-message-enable=true
 banner-message-text='<banner message>'
 Remediation:
-Create the /etc/dconf/profile/gdm file with the following contents:
+Create the /etc/dconf/profile/gdm  file with the following contents:
 user-db:user
 system-db:gdm
 file-db:/usr/share/gdm/greeter-dconf-defaults
-Create or edit the banner-message-enable and banner-message-text options
-in /etc/dconf/db/gdm.d/01-banner-message:
+Create or edit thebanner-message-enable  and banner-message-text  options
+in/etc/dconf/db/gdm.d/01-banner-message   :
 [org/gnome/login-screen]
 banner-message-enable=true
 banner-message-text='Authorized uses only. All activity may be monitored and
@@ -1462,7 +1425,8 @@ reported.'
 Run the following command to update the system databases:
 # dconf update
 Notes:
-Additional options and sections may appear in the /etc/dconf/db/gdm.d/01-bannermessage file.
+Additional options and sections may appear in the  /etc/dconf/db/gdm.d/01-banner-
+message file.
 If a different GUI login service is in use, consult your documentation and apply an
 equivalent banner.
 
@@ -1488,6 +1452,18 @@ Use your package manager to update all packages on the system according to site 
 Notes:
 Site policy may mandate a testing period before install onto production systems for
 available updates.
+2 Services
+While applying system updates and patches helps correct known vulnerabilities, one of the
+best ways to protect the system against as yet unreported vulnerabilities is to disable all
+services that are not required for normal system operation. This prevents the exploitation
+of vulnerabilities discovered at a later date. If a service is not enabled, it cannot be
+exploited. The actions in this section of the document provide guidance on some services
+
+which can be safely disabled and under which circumstances, greatly reducing the number
+of possible threats to the resulting system. Additionally some services which should
+remain enabled but with secure configuration are covered as well as insecure service
+clients.
+
 2.1 inetd Services
 inetd is a super-server daemon that provides internet services and passes connections to
 configured services. While not commonly used inetd and any unneeded inetd based
@@ -1496,23 +1472,22 @@ services should be disabled if possible.
 2.1.1 Ensure chargen services are not enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-is a network service that responds with 0 to 512 ASCII characters for each
+chargen is a network service that responds with 0 to 512 ASCII characters for each
 connection it receives. This service is intended for debugging and testing purposes. It is
 recommended that this service be disabled.
-chargen
 Rationale:
 Disabling this service will reduce the remote attack surface of the system.
 Audit:
-Verify the chargen service is not enabled. Run the following command and verify results
+Verify thechargen service is not enabled. Run the following command and verify results
 are as indicated:
 grep -R "^chargen" /etc/inetd.*
 No results should be returned
-check /etc/xinetd.conf and /etc/xinetd.d/* and verify all chargen services have
+check /etc/xinetd.conf  and /etc/xinetd.d/*  and verify alchargen services have
 disable = yes set.
 Remediation:
 Comment out or remove any lines starting with chargen from /etc/inetd.conf and
-/etc/inetd.d/*.
-Set disable = yes on all chargen services in /etc/xinetd.conf and /etc/xinetd.d/*.
+/etc/inetd.d/* .
+Set disable = yes on allchargen services in/etc/xinetd.conf  and /etc/xinetd.d/*  .
 
 
 
@@ -1525,92 +1500,89 @@ be disabled.
 Rationale:
 Disabling this service will reduce the remote attack surface of the system.
 Audit:
-Verify the daytime service is not enabled. Run the following command and verify results
+Verify thedaytime service is not enabled. Run the following command and verify results
 are as indicated:
 grep -R "^daytime" /etc/inetd.*
 No results should be returned
-check /etc/xinetd.conf and /etc/xinetd.d/* and verify all daytime services
-have disable = yes set.
+check /etc/xinetd.conf  and /etc/xinetd.d/*  and verify aldaytime services
+have disable = yes  set.
 Remediation:
 Comment out or remove any lines starting
-with daytime from /etc/inetd.conf and /etc/inetd.d/*.
-Set disable = yes on all daytime services in /etc/xinetd.conf and /etc/xinetd.d/*.
+with daytime from /etc/inetd.conf and /etc/inetd.d/* .
+Set disable = yes on alldaytime services in/etc/xinetd.conf  and /etc/xinetd.d/*  .
 
 
 
 2.1.3 Ensure discard services are not enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-is a network service that simply discards all data it receives. This service is
+discard is a network service that simply discards all data it receives. This service is
 intended for debugging and testing purposes. It is recommended that this service be
 disabled.
-discard
 Rationale:
 Disabling this service will reduce the remote attack surface of the system.
 Audit:
-Verify the discard service is not enabled. Run the following command and verify results
+Verify thediscard service is not enabled. Run the following command and verify results
 are as indicated:
 grep -R "^discard" /etc/inetd.*
 No results should be returned
-check /etc/xinetd.conf and /etc/xinetd.d/* and verify all discard services
-have disable = yes set.
+check /etc/xinetd.conf  and /etc/xinetd.d/*  and verify aldiscard services
+have disable = yes  set.
 Remediation:
 Comment out or remove any lines starting
-with discard from /etc/inetd.conf and /etc/inetd.d/*.
-Set disable = yes on all discard services in /etc/xinetd.conf and /etc/xinetd.d/*.
+with discard from /etc/inetd.conf and /etc/inetd.d/* .
+Set disable = yes on alldiscard services in/etc/xinetd.conf  and /etc/xinetd.d/*  .
 
 
 
 2.1.4 Ensure echo services are not enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-is a network service that responds to clients with the data sent to it by the client. This
+echo is a network service that responds to clients with the data sent to it by the client. This
 service is intended for debugging and testing purposes. It is recommended that this service
 be disabled.
-echo
 Rationale:
 Disabling this service will reduce the remote attack surface of the system.
 Audit:
-Verify the echo service is not enabled. Run the following command and verify results are as
+Verify theecho service is not enabled. Run the following command and verify results are as
 indicated:
 grep -R "^echo" /etc/inetd.*
 No results should be returned
-check /etc/xinetd.conf and /etc/xinetd.d/* and verify all echo services have disable
+check /etc/xinetd.conf  and /etc/xinetd.d/*  and verify alecho services have disable
 = yes set.
 Remediation:
 Comment out or remove any lines starting
-with echo from /etc/inetd.conf and /etc/inetd.d/*.
-Set disable = yes on all echo services in /etc/xinetd.conf and /etc/xinetd.d/*.
+with echo from /etc/inetd.conf  and /etc/inetd.d/* .
+Set disable = yes on allecho services in/etc/xinetd.conf  and /etc/xinetd.d/* .
 
 
 
 2.1.5 Ensure time services are not enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-is a network service that responds with the server's current date and time as a 32 bit
+time is a network service that responds with the server's current date and time as a 32 bit
 integer. This service is intended for debugging and testing purposes. It is recommended
 that this service be disabled.
-time
 Rationale:
 Disabling this service will reduce the remote attack surface of the system.
 Audit:
-Verify the time service is not enabled. Run the following command and verify results are as
+Verify thetime service is not enabled. Run the following command and verify results are as
 indicated:
 grep -R "^time" /etc/inetd.*
 No results should be returned
-check /etc/xinetd.conf and /etc/xinetd.d/* and verify all time services have disable
+check /etc/xinetd.conf  and /etc/xinetd.d/*  and verify altime services have disable
 = yes set.
 Remediation:
 Comment out or remove any lines starting
-with time from /etc/inetd.conf and /etc/inetd.d/*.
-Set disable = yes on all time services in /etc/xinetd.conf and /etc/xinetd.d/*.
+with time from /etc/inetd.conf  and /etc/inetd.d/* .
+Set disable = yes on alltime services in/etc/xinetd.conf  and /etc/xinetd.d/* .
 
 
 
 2.1.6 Ensure rsh server is not enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The Berkeley rsh-server (rsh, rlogin, rexec) package contains legacy services that
+The Berkeley rsh-server  (rsh ,rlogin ,rexec ) package contains legacy services that
 exchange credentials in clear-text.
 Rationale:
 These legacy services contain numerous security exposures and have been replaced with
@@ -1622,13 +1594,13 @@ grep -R "^shell" /etc/inetd.*
 grep -R "^login" /etc/inetd.*
 grep -R "^exec" /etc/inetd.*
 No results should be returned
-check /etc/xinetd.conf and /etc/xinetd.d/* and verify all rsh, rlogin, and
-rexec services have disable = yes set.
+check /etc/xinetd.conf  and /etc/xinetd.d/*  and verify allrsh ,rlogin , and
+rexec services have disable = yes  set.
 Remediation:
-Comment out or remove any lines starting with shell, login, or
-exec from /etc/inetd.conf and /etc/inetd.d/*.
-Set disable = yes on all rsh, rlogin,
-and rexec services in /etc/xinetd.conf and /etc/xinetd.d/*.
+Comment out or remove any lines starting with  shell ,login , or
+exec from /etc/inetd.conf  and /etc/inetd.d/*  .
+Set disable = yes  on allrsh ,rlogin ,
+and rexec services in/etc/xinetd.conf  and /etc/xinetd.d/*  .
 
 
 
@@ -1641,40 +1613,39 @@ default.
 Rationale:
 The software presents a security risk as it uses unencrypted protocols for communication.
 Audit:
-Verify the talk service is not enabled. Run the following commands and verify results are
+Verify thetalk service is not enabled. Run the following commands and verify results are
 as indicated:
-grep -R "^talk" /etc/inetd.*
 grep -R "^ntalk" /etc/inetd.*
 No results should be returned
-check /etc/xinetd.conf and /etc/xinetd.d/* and verify all talk services have disable =
+check /etc/xinetd.conf  and /etc/xinetd.d/*  and verify all talk services havdisable =
 yes set.
 Remediation:
 Comment out or remove any lines starting with talk or ntalk
-from /etc/inetd.conf and /etc/inetd.d/*.
-Set disable = yes on all talk services in /etc/xinetd.conf and /etc/xinetd.d/*.
+from /etc/inetd.conf  and /etc/inetd.d/*  .
+Set disable = yes on alltalk services in/etc/xinetd.conf  and /etc/xinetd.d/*  .
 
 
 
 2.1.8 Ensure telnet server is not enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The telnet-server package contains the telnet daemon, which accepts connections
-from users from other systems via the telnet protocol.
+The telnet-server  package contains the telnet daemon, which accepts connections
+from users from other systems via thetelnet protocol.
 Rationale:
 The telnet protocol is insecure and unencrypted. The use of an unencrypted transmission
 medium could allow a user with access to sniff network traffic the ability to steal
-credentials. The ssh package provides an encrypted session and stronger security.
+credentials. Thessh package provides an encrypted session and stronger security.
 Audit:
-Verify the telnet service is not enabled. Run the following command and verify results are
+Verify thetelnet service is not enabled. Run the following command and verify results are
 as indicated:
 grep -R "^telnet" /etc/inetd.*
 No results should be returned
-check /etc/xinetd.conf and /etc/xinetd.d/* and verify all telnet services
+check /etc/xinetd.conf  and /etc/xinetd.d/* and verify alltelnet services
 have disable = yes set.
 Remediation:
 Comment out or remove any lines starting
-with telnet from /etc/inetd.conf and /etc/inetd.d/*.
-Set disable = yes on all telnet services in /etc/xinetd.conf and /etc/xinetd.d/*.
+with telnet from /etc/inetd.conf  and /etc/inetd.d/* .
+Set disable = yes on alltelnet services in/etc/xinetd.conf and /etc/xinetd.d/* .
 
 
 
@@ -1689,34 +1660,34 @@ TFTP does not support authentication nor does it ensure the confidentiality or i
 data. It is recommended that TFTP be removed, unless there is a specific need for TFTP. In
 that case, extreme caution must be used when configuring the services.
 Audit:
-Verify the tftp service is not enabled. Run the following command and verify results are as
+Verify thetftp service is not enabled. Run the following command and verify results are as
 indicated:
 grep -R "^tftp" /etc/inetd.*
 No results should be returned
-check /etc/xinetd.conf and /etc/xinetd.d/* and verify all tftp services have disable
+check /etc/xinetd.conf  and /etc/xinetd.d/*  and verify altftp services have disable
 = yes set.
 Remediation:
 Comment out or remove any lines starting
-with tftp from /etc/inetd.conf and /etc/inetd.d/*.
-Set disable = yes on all tftp services in /etc/xinetd.conf and /etc/xinetd.d/*.
+with tftp from /etc/inetd.conf  and /etc/inetd.d/* .
+Set disable = yes on alltftp services in/etc/xinetd.conf  and /etc/xinetd.d/* .
 
 
 
 2.1.10 Ensure xinetd is not enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The eXtended InterNET Daemon (xinetd) is an open source super daemon that replaced
-the original inetd daemon. The xinetd daemon listens for well known services and
+The eXtended InterNET Daemon (  xinetd ) is an open source super daemon that replaced
+the originalinetd daemon. The xinetd daemon listens for well known services and
 dispatches the appropriate daemon to properly respond to service requests.
 Rationale:
-If there are no xinetd services required, it is recommended that the daemon be disabled.
+If there are nxinetd services required, it is recommended that the daemon be disabled.
 Audit:
 Run the following command to verify xinetd is not enabled:
 # systemctl is-enabled xinetd
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable xinetd:
+Run the following command to disable xinetd :
 # systemctl disable xinetd
 Notes:
 Additional methods of disabling a service exist. Consult your distribution documentation
@@ -1761,10 +1732,9 @@ virtualization software documentation and setup host based synchronization.
 2.2.1.2 Ensure ntp is configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-ntp is a daemon which implements the Network Time Protocol (NTP).
-It is designed to
+ntp is a daemon which implements the Network Time Protocol (NTP). It is designed to
 synchronize system clocks across a variety of systems and use a source that is highly
-accurate. More information on NTP can be found at http://www.ntp.org. ntp can be
+accurate. More information on NTP can be found at http://www.ntp.org.  ntp can be
 configured to be a client and/or a server.
 This recommendation only applies if ntp is in use on the system.
 Rationale:
@@ -1775,24 +1745,24 @@ Run the following command and verify output matches:
 # grep "^restrict" /etc/ntp.conf
 restrict -4 default kod nomodify notrap nopeer noquery
 restrict -6 default kod nomodify notrap nopeer noquery
-The -4 in the first line is optional and options after default can appear in any
+The -4 in the first line is optional and options adefault can appear in any
 order. Additional restriction lines may exist.
 Run the following command and verify remote server is configured properly:
 # grep "^server" /etc/ntp.conf
 server <remote-server>
 Multiple servers may be configured.
-Verify that ntp is configured to run as the ntp user by running the following command:
+Verify thatntp is configured to run as thntp user by running the following command:
 # grep "RUNASUSER=ntp" /etc/init.d/ntp
 RUNASUSER=ntp
 Remediation:
 
-Add or edit restrict lines in /etc/ntp.conf to match the following:
+Add or edit restrict lines i/etc/ntp.conf  to match the following:
 restrict -4 default kod nomodify notrap nopeer noquery
 restrict -6 default kod nomodify notrap nopeer noquery
-Add or edit server lines to /etc/ntp.conf as appropriate:
+Add or edit server lines to/etc/ntp.conf  as appropriate:
 server <remote-server>
 Configure ntp to run as the ntp user by adding or editing the following file:
-/etc/init.d/ntp:
+/etc/init.d/ntp  :
 RUNASUSER=ntp
 
 
@@ -1813,17 +1783,14 @@ Run the following command and verify remote server is configured properly:
 # grep "^server" /etc/chrony/chrony.conf
 server <remote-server>
 Multiple servers may be configured.
-Run the following command and verify the first field for the chronyd process is _chrony:
+Run the following command and verify the first field for thechronyd process is chrony :
 # ps -ef | grep chronyd
-_chrony
-491
-1 0 20:32 ?
-00:00:00 /usr/sbin/chronyd
+_chrony   491   1 0 20:32 ?     00:00:00 /usr/sbin/chronyd
 Remediation:
-Add or edit server lines to /etc/chrony/chrony.conf as appropriate:
+Add or edit server lines to/etc/chrony/chrony.conf  as appropriate:
 server <remote-server>
-Configure chrony to run as the chrony user by configuring the appropriate startup script
-for your distribution. Startup scripts are typically stored in /etc/init.d or /etc/systemd.
+Configure chrony to run as thechrony user by configuring the appropriate startup script
+for your distribution. Startup scripts are typically stored /etc/init.d or /etc/systemd .
 
 
 
@@ -1859,12 +1826,12 @@ Automatic discovery of network services is not normally required for system
 functionality. It is recommended to disable the service to reduce the potential attach
 surface.
 Audit:
-Run the following command to verify avahi-daemon is not enabled:
+Run the following command to verify  avahi-daemon  is not enabled:
 # systemctl is-enabled avahi-daemon
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable avahi-daemon:
+Run the following command to disable  avahi-daemon  :
 # systemctl disable avahi-daemon
 
 
@@ -1885,7 +1852,7 @@ Run the following command to verify cups is not enabled:
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable cups:
+Run the following command to disable  cups:
 # systemctl disable cups
 Impact:
 Disabling CUPS will prevent printing from the system, a common task for workstation
@@ -1936,7 +1903,7 @@ Run the following command to verify slapd is not enabled:
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable slapd:
+Run the following command to disable  slapd :
 # systemctl disable slapd
 References:
 1. For more detailed documentation on OpenLDAP, go to the project homepage at
@@ -1958,12 +1925,12 @@ Run the following command to verify nfs is not enabled:
 # systemctl is-enabled nfs-kernel-server
 disabled
 Verify result is not "enabled".
-Run the following command to verify rpcbind is not enabled:
+Run the following command to verify rpcbind  is not enabled:
 # systemctl is-enabled rpcbind
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following commands to disable nfs and rpcbind:
+Run the following commands to disable  nfs and rpcbind :
 # systemctl disable nfs-kernel-server
 # systemctl disable rpcbind
 
@@ -1978,12 +1945,12 @@ Rationale:
 Unless a system is specifically designated to act as a DNS server, it is recommended that the
 package be deleted to reduce the potential attack surface.
 Audit:
-Run one of the following commands to verify named is not enabled:
+Run one of the following commands to verify named  is not enabled:
 # systemctl is-enabled bind9
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable named:
+Run the following command to disable  named :
 # systemctl disable bind9
 
 
@@ -1999,12 +1966,12 @@ recommended sftp be used if file transfer is required. Unless there is a need to
 system as a FTP server (for example, to allow anonymous downloads), it is recommended
 that the package be deleted to reduce the potential attack surface.
 Audit:
-Run the following command to verify vsftpd is not enabled:
+Run the following command to verify  vsftpd  is not enabled:
 # systemctl is-enabled vsftpd
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable vsftpd:
+Run the following command to disable  vsftpd :
 # systemctl disable vsftpd
 Notes:
 Additional FTP servers also exist and should be audited.
@@ -2019,12 +1986,12 @@ Rationale:
 Unless there is a need to run the system as a web server, it is recommended that the
 package be deleted to reduce the potential attack surface.
 Audit:
-Run the following command to verify apache2 is not enabled:
+Run the following command to verify  apache2 is not enabled:
 # systemctl is-enabled apache2
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable apache2:
+Run the following command to disable  apache2 :
 # systemctl disable apache2
 
 
@@ -2042,10 +2009,11 @@ Run the following command to verify dovecot is not enabled:
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable dovecot:
+Run the following command to disable dovecot :
 # systemctl disable dovecot
 Notes:
-Several IMAP/POP3 servers exist and can use other service names. exim and cyrusimap are example services that provide an HTTP server. These and other services should
+Several IMAP/POP3 servers exist and can use other service names. exim and cyrus-
+imap are example services that provide an HTTP server. These and other services should
 also be audited.
 
 
@@ -2061,12 +2029,12 @@ Rationale:
 If there is no need to mount directories and file systems to Windows systems, then this
 service can be deleted to reduce the potential attack surface.
 Audit:
-Run the following command to verify smbd is not enabled:
+Run the following command to verify  smbd is not enabled:
 # systemctl is-enabled smbd
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable smbd:
+Run the following command to disable  smbd :
 # systemctl disable smbd
 
 
@@ -2079,12 +2047,11 @@ Rationale:
 If there is no need for a proxy server, it is recommended that the squid proxy be deleted to
 reduce the potential attack surface.
 Audit:
-Run the following command to verify squid is not enabled:
-# systemctl is-enabled squid
-disabled
+Run the following command to verify  squid is not enabled:
+disabledctl is-enabled squid
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable squid:
+Run the following command to disable  squid :
 # systemctl disable squid
 
 
@@ -2105,7 +2072,7 @@ Run the following command to verify snmpd is not enabled:
 disabled
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable snmpd:
+Run the following command to disable  snmpd :
 # systemctl disable snmpd
 
 
@@ -2129,7 +2096,7 @@ address (127.0.0.1 or ::1):
 # netstat -an | grep LIST | grep ":25[[:space:]]"
 tcp 0 0 127.0.0.1:25 0.0.0.0:* LISTEN
 Remediation:
-Edit /etc/postfix/main.cf and add the following line to the RECEIVING MAIL section. If
+Edit /etc/postfix/main.cf  and add the following line to the RECEIVING MAIL section. If
 the line already exists, change it to look like the line below:
 inet_interfaces = localhost
 Restart postfix:
@@ -2173,12 +2140,11 @@ buffer overflows and has poor authentication for querying NIS maps. NIS generall
 replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is
 recommended that the service be disabled and other, more secure services be used
 Audit:
-Run the following command to verify nis is not enabled:
-# systemctl is-enabled nis
-disabled
+Run the following command to verify  nis is not enabled:
+disabledctl is-enabled nis
 Verify result is not "enabled".
 Remediation:
-Run the following command to disable nis:
+Run the following command to disable  nis :
 # systemctl disable nis
 
 2.3 Service Clients
@@ -2192,7 +2158,7 @@ Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 The Network Information Service (NIS), formerly known as Yellow Pages, is a client-server
 directory service protocol used to distribute system configuration files. The NIS client
-(ypbind) was used to bind a machine to an NIS server and receive the distributed
+(ypbind ) was used to bind a machine to an NIS server and receive the distributed
 configuration files.
 Rationale:
 The NIS service is inherently an insecure system that has been vulnerable to DOS attacks,
@@ -2200,7 +2166,7 @@ buffer overflows and has poor authentication for querying NIS maps. NIS generall
 been replaced by such protocols as Lightweight Directory Access Protocol (LDAP). It is
 recommended that the service be removed.
 Audit:
-Run the following command and verify nis is not installed:
+Run the following command and verify  nis is not installed:
 dpkg -s nis
 Remediation:
 Run the following command to uninstall nis:
@@ -2223,13 +2189,12 @@ These legacy clients contain numerous security exposures and have been replaced 
 more secure SSH package. Even if the server is removed, it is best to ensure the clients are
 also removed to prevent users from inadvertently attempting to use these commands and
 therefore exposing their credentials. Note that removing the rsh package removes the
-clients for rsh, rcp and rlogin.
+clients forrsh,rcp and rlogin .
 Audit:
-Run the following commands and verify rsh is not installed:
-dpkg -s rsh-client
+Run the following commands and verify  rsh is not installed:
 dpkg -s rsh-redone-client
 Remediation:
-Run the following command to uninstall rsh:
+Run the following command to uninstall  rsh :
 apt-get remove rsh-client rsh-redone-client
 Impact:
 Many insecure service clients are used as troubleshooting tools and in testing
@@ -2248,10 +2213,10 @@ sessions, is installed by default.
 Rationale:
 The software presents a security risk as it uses unencrypted protocols for communication.
 Audit:
-Run the following command and verify talk is not installed:
+Run the following command and verify  talk is not installed:
 dpkg -s talk
 Remediation:
-Run the following command to uninstall talk:
+Run the following command to uninstall talk :
 apt-get remove talk
 Impact:
 Many insecure service clients are used as troubleshooting tools and in testing
@@ -2274,7 +2239,7 @@ Audit:
 Run the following command and verify telnet is not installed:
 # dpkg -s telnet
 Remediation:
-Run the following command to uninstall telnet:
+Run the following command to uninstall telnet :
 # apt-get remove telnet
 Impact:
 Many insecure service clients are used as troubleshooting tools and in testing
@@ -2297,11 +2262,16 @@ Audit:
 Run the following command and verify ldap-utils is not installed:
 # dpkg -s ldap-utils
 Remediation:
-Uninstall ldap-utils using the appropriate package manager or manual installation:
+Uninstallldap-utils using the appropriate package manager or manual installation:
 # apt-get remove ldap-utils
 Impact:
 Removing the LDAP client will prevent or inhibit using LDAP for authentication in your
 environment.
+3 Network Configuration
+This section provides guidance on for securing the network configuration of the system
+through kernel parameters, access list control, and firewall settings.
+
+
 
 3.1 Network Parameters (Host Only)
 The following network parameters are intended for use if the system is to act as a host
@@ -2311,7 +2281,7 @@ interfaces but will not be configured as a router.
 3.1.1 Ensure IP forwarding is disabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The net.ipv4.ip_forward flag is used to tell the system whether it can forward packets or
+The net.ipv4.ip_forward  flag is used to tell the system whether it can forward packets or
 not.
 Rationale:
 Setting the flag to 0 ensures that a system with multiple interfaces (for example, a hard
@@ -2321,10 +2291,9 @@ Run the following command and verify output matches:
 # sysctl net.ipv4.ip_forward
 net.ipv4.ip_forward = 0
 Remediation:
-Set the following parameter in the /etc/sysctl.conf file:
+Set the following parameter in the/etc/sysctl.conf  file:
 net.ipv4.ip_forward = 0
 Run the following commands to set the active kernel parameters:
-# sysctl -w net.ipv4.ip_forward=0
 # sysctl -w net.ipv4.route.flush=1
 
 
@@ -2345,11 +2314,10 @@ net.ipv4.conf.all.send_redirects = 0
 # sysctl net.ipv4.conf.default.send_redirects
 net.ipv4.conf.default.send_redirects = 0
 Remediation:
-Set the following parameters in the /etc/sysctl.conf file:
+Set the following parameters in the /etc/sysctl.conf  file:
 net.ipv4.conf.all.send_redirects = 0
 net.ipv4.conf.default.send_redirects = 0
 Run the following commands to set the active kernel parameters:
-# sysctl -w net.ipv4.conf.all.send_redirects=0
 # sysctl -w net.ipv4.conf.default.send_redirects=0
 # sysctl -w net.ipv4.route.flush=1
 
@@ -2369,8 +2337,8 @@ by routers in the network. In some cases, systems may not be routable or reachab
 some locations (e.g. private addresses vs. Internet routable), and so source routed packets
 would need to be used.
 Rationale:
-Setting net.ipv4.conf.all.accept_source_route and
-net.ipv4.conf.default.accept_source_route to 0 disables the system from accepting
+Settingnet.ipv4.conf.all.accept_source_route    and
+net.ipv4.conf.default.accept_source_route    to 0 disables the system from accepting
 source routed packets. Assume this system was capable of routing packets to Internet
 routable addresses on one interface and private addresses on another interface. Assume
 that the private addresses were not routable to the Internet routable addresses and vice
@@ -2387,7 +2355,7 @@ net.ipv4.conf.all.accept_source_route = 0
 net.ipv4.conf.default.accept_source_route = 0
 
 Remediation:
-Set the following parameters in the /etc/sysctl.conf file:
+Set the following parameters in the /etc/sysctl.conf  file:
 net.ipv4.conf.all.accept_source_route = 0
 net.ipv4.conf.default.accept_source_route = 0
 Run the following commands to set the active kernel parameters:
@@ -2403,7 +2371,7 @@ Description:
 ICMP redirect messages are packets that convey routing information and tell your host
 (acting as a router) to send packets via an alternate path. It is a way of allowing an outside
 routing device to update your system routing tables. By setting
-net.ipv4.conf.all.accept_redirects to 0, the system will not accept any ICMP redirect
+net.ipv4.conf.all.accept_redirects    to 0, the system will not accept any ICMP redirect
 messages, and therefore, won't allow outsiders to update the system's routing tables.
 Rationale:
 Attackers could use bogus ICMP redirect messages to maliciously alter the system routing
@@ -2413,10 +2381,9 @@ Audit:
 Run the following commands and verify output matches:
 # sysctl net.ipv4.conf.all.accept_redirects
 net.ipv4.conf.all.accept_redirects = 0
-# sysctl net.ipv4.conf.default.accept_redirects
-net.ipv4.conf.default.accept_redirects = 0
+net.ipv4.conf.default.accept_redirects = 0rects
 Remediation:
-Set the following parameters in the /etc/sysctl.conf file:
+Set the following parameters in the /etc/sysctl.conf  file:
 net.ipv4.conf.all.accept_redirects = 0
 net.ipv4.conf.default.accept_redirects = 0
 Run the following commands to set the active kernel parameters:
@@ -2434,7 +2401,7 @@ listed on the default gateway list. It is assumed that these gateways are known 
 system, and that they are likely to be secure.
 Rationale:
 It is still possible for even known gateways to be compromised. Setting
-net.ipv4.conf.all.secure_redirects to 0 protects the system from routing table
+net.ipv4.conf.all.secure_redirects    to 0 protects the system from routing table
 updates by possibly compromised known gateways.
 Audit:
 Run the following commands and verify output matches:
@@ -2443,7 +2410,7 @@ net.ipv4.conf.all.secure_redirects = 0
 # sysctl net.ipv4.conf.default.secure_redirects
 net.ipv4.conf.default.secure_redirects = 0
 Remediation:
-Set the following parameters in the /etc/sysctl.conf file:
+Set the following parameters in the/etc/sysctl.conf  file:
 net.ipv4.conf.all.secure_redirects = 0
 net.ipv4.conf.default.secure_redirects = 0
 Run the following commands to set the active kernel parameters:
@@ -2468,7 +2435,7 @@ net.ipv4.conf.all.log_martians = 1
 # sysctl net.ipv4.conf.default.log_martians
 net.ipv4.conf.default.log_martians = 1
 Remediation:
-Set the following parameters in the /etc/sysctl.conf file:
+Set the following parameters in the /etc/sysctl.conf  file:
 net.ipv4.conf.all.log_martians = 1
 net.ipv4.conf.default.log_martians = 1
 Run the following commands to set the active kernel parameters:
@@ -2481,7 +2448,7 @@ Run the following commands to set the active kernel parameters:
 3.2.5 Ensure broadcast ICMP requests are ignored (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-Setting net.ipv4.icmp_echo_ignore_broadcasts to 1 will cause the system to ignore all
+Setting net.ipv4.icmp_echo_ignore_broadcasts    to 1 will cause the system to ignore all
 ICMP echo and timestamp requests to broadcast and multicast addresses.
 Rationale:
 Accepting ICMP echo and timestamp requests with broadcast or multicast destinations for
@@ -2496,7 +2463,7 @@ Run the following commands and verify output matches:
 # sysctl net.ipv4.icmp_echo_ignore_broadcasts
 net.ipv4.icmp_echo_ignore_broadcasts = 1
 Remediation:
-Set the following parameter in the /etc/sysctl.conf file:
+Set the following parameter in the /etc/sysctl.conf  file:
 net.ipv4.icmp_echo_ignore_broadcasts = 1
 Run the following commands to set the active kernel parameters:
 # sysctl -w net.ipv4.icmp_echo_ignore_broadcasts=1
@@ -2507,7 +2474,7 @@ Run the following commands to set the active kernel parameters:
 3.2.6 Ensure bogus ICMP responses are ignored (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-Setting icmp_ignore_bogus_error_responses to 1 prevents the kernel from logging bogus
+Setting icmp_ignore_bogus_error_responses   to 1 prevents the kernel from logging bogus
 responses (RFC-1122 non-compliant) from broadcast reframes, keeping file systems from
 filling up with useless log messages.
 Rationale:
@@ -2518,7 +2485,7 @@ Run the following commands and verify output matches:
 # sysctl net.ipv4.icmp_ignore_bogus_error_responses
 net.ipv4.icmp_ignore_bogus_error_responses = 1
 Remediation:
-Set the following parameter in the /etc/sysctl.conf file:
+Set the following parameter in the/etc/sysctl.conf  file:
 net.ipv4.icmp_ignore_bogus_error_responses = 1
 Run the following commands to set the active kernel parameters:
 # sysctl -w net.ipv4.icmp_ignore_bogus_error_responses=1
@@ -2529,11 +2496,11 @@ Run the following commands to set the active kernel parameters:
 3.2.7 Ensure Reverse Path Filtering is enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-Setting net.ipv4.conf.all.rp_filter and net.ipv4.conf.default.rp_filter to 1
+Setting net.ipv4.conf.all.rp_filter   and net.ipv4.conf.default.rp_filter   to 1
 forces the Linux kernel to utilize reverse path filtering on a received packet to determine if
 the packet was valid. Essentially, with reverse path filtering, if the return packet does not
 go out the same interface that the corresponding source packet came from, the packet is
-dropped (and logged if log_martians is set).
+dropped (and logged if log_martians  is set).
 Rationale:
 Setting these flags is a good way to deter attackers from sending your system bogus
 packets that cannot be responded to. One instance where this feature breaks down is if
@@ -2544,10 +2511,9 @@ Audit:
 Run the following commands and verify output matches:
 # sysctl net.ipv4.conf.all.rp_filter
 net.ipv4.conf.all.rp_filter = 1
-# sysctl net.ipv4.conf.default.rp_filter
-net.ipv4.conf.default.rp_filter = 1
+net.ipv4.conf.default.rp_filter = 1ilter
 Remediation:
-Set the following parameters in the /etc/sysctl.conf file:
+Set the following parameters in the /etc/sysctl.conf  file:
 net.ipv4.conf.all.rp_filter = 1
 net.ipv4.conf.default.rp_filter = 1
 Run the following commands to set the active kernel parameters:
@@ -2560,7 +2526,7 @@ Run the following commands to set the active kernel parameters:
 3.2.8 Ensure TCP SYN Cookies is enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-When tcp_syncookies is set, the kernel will handle TCP SYN packets normally until the
+When tcp_syncookies  is set, the kernel will handle TCP SYN packets normally until the
 half-open connection queue is full, at which time, the SYN cookie functionality kicks in. SYN
 cookies work by not using the SYN queue at all. Instead, the kernel simply replies to the
 SYN with a SYN|ACK, but will include a specially crafted TCP sequence number that
@@ -2580,7 +2546,7 @@ Run the following commands and verify output matches:
 # sysctl net.ipv4.tcp_syncookies
 net.ipv4.tcp_syncookies = 1
 Remediation:
-Set the following parameter in the /etc/sysctl.conf file:
+Set the following parameter in the/etc/sysctl.conf  file:
 net.ipv4.tcp_syncookies = 1
 Run the following commands to set the active kernel parameters:
 # sysctl -w net.ipv4.tcp_syncookies=1
@@ -2606,8 +2572,7 @@ net.ipv6.conf.all.accept_ra = 0
 # sysctl net.ipv6.conf.default.accept_ra
 net.ipv6.conf.default.accept_ra = 0
 Remediation:
-Set the following parameters in the /etc/sysctl.conf file:
-net.ipv6.conf.all.accept_ra = 0
+Set the following parameters in the/etc/sysctl.conf  file:
 net.ipv6.conf.default.accept_ra = 0
 Run the following commands to set the active kernel parameters:
 # sysctl -w net.ipv6.conf.all.accept_ra=0
@@ -2632,11 +2597,10 @@ net.ipv6.conf.all.accept_redirect = 0
 # sysctl net.ipv6.conf.default.accept_redirects
 net.ipv6.conf.default.accept_redirect = 0
 Remediation:
-Set the following parameters in the /etc/sysctl.conf file:
+Set the following parameters in the /etc/sysctl.conf  file:
 net.ipv6.conf.all.accept_redirects = 0
 net.ipv6.conf.default.accept_redirects = 0
 Run the following commands to set the active kernel parameters:
-# sysctl -w net.ipv6.conf.all.accept_redirects=0
 # sysctl -w net.ipv6.conf.default.accept_redirects=0
 # sysctl -w net.ipv6.route.flush=1
 
@@ -2654,7 +2618,7 @@ Run the following command and verify that each linux line has
 the 'ipv6.disable=1' parameter set:
 # grep "^\s*linux" /boot/grub/grub.cfg
 Remediation:
-Edit /etc/default/grub and add 'ipv6.disable=1' to GRUB_CMDLINE_LINUX:
+Edit/etc/default/grub  and add 'ipv6.disable=1' to GRUB_CMDLINE_LINUX:
 GRUB_CMDLINE_LINUX="ipv6.disable=1"
 Run the following command to update the grub2 configuration:
 # update-grub
@@ -2667,9 +2631,9 @@ Run the following command to update the grub2 configuration:
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 TCP Wrappers provides a simple access list and standardized logging method for services
-capable of supporting it. In the past, services that were called from inetd and xinetd
-supported the use of tcp wrappers. As inetd and xinetd have been falling in disuse, any
-service that can support tcp wrappers will have the libwrap.so library attached to it.
+capable of supporting it. In the past, services that were calledinetd and xinetd
+supported the use of tcp wrappers. Asinetd and xinetd have been falling in disuse, any
+service that can support tcp wrappers will have thlibwrap.so library attached to it.
 Rationale:
 TCP Wrappers provide a good simple access list mechanism to services that may not have
 that support built in. It is recommended that all services that can support TCP Wrappers,
@@ -2690,42 +2654,42 @@ If there is any output, then the service supports TCP Wrappers.
 3.4.2 Ensure /etc/hosts.allow is configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/hosts.allow file specifies which IP addresses are permitted to connect to the
-host. It is intended to be used in conjunction with the /etc/hosts.deny file.
+The /etc/hosts.allow  file specifies which IP addresses are permitted to connect to the
+host. It is intended to be used in conjunction with t/etc/hosts.deny  file.
 Rationale:
-The /etc/hosts.allow file supports access control by IP and helps ensure that only
+The /etc/hosts.allow  file supports access control by IP and helps ensure that only
 authorized systems can connect to the system.
 Audit:
-Run the following command and verify the contents of the /etc/hosts.allow file:
+Run the following command and verify the contents of the /etc/hosts.allow  file:
 # cat /etc/hosts.allow
 Remediation:
-Run the following command to create /etc/hosts.allow:
+Run the following command to create  /etc/hosts.allow :
 # echo "ALL: <net>/<mask>, <net>/<mask>, ..." >/etc/hosts.allow
 where each <net>/<mask> combination (for example, "192.168.1.0/255.255.255.0")
 represents one network block in use by your organization that requires access to this
 system.
 Notes:
-Contents of the /etc/hosts.allow file will vary depending on your network configuration.
+Contents of the /etc/hosts.allow  file will vary depending on your network configuration.
 
 
 
 3.4.3 Ensure /etc/hosts.deny is configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/hosts.deny file specifies which IP addresses are not permitted to connect to the
-host. It is intended to be used in conjunction with the /etc/hosts.allow file.
+The /etc/hosts.deny  file specifies which IP addresses are not permitted to connect to the
+host. It is intended to be used in conjunction with t/etc/hosts.allow  file.
 Rationale:
-The /etc/hosts.deny file serves as a failsafe so that any host not specified in
-/etc/hosts.allow is denied access to the system.
+The /etc/hosts.deny  file serves as a failsafe so that any host not specified in
+/etc/hosts.allow  is denied access to the system.
 Audit:
-Run the following command and verify the contents of the /etc/hosts.deny file:
+Run the following command and verify the contents of the /etc/hosts.deny  file:
 # cat /etc/hosts.deny
 ALL: ALL
 Remediation:
-Run the following command to create /etc/hosts.deny:
+Run the following command to create  /etc/hosts.deny :
 # echo "ALL: ALL" >> /etc/hosts.deny
 Notes:
-Contents of the /etc/hosts.deny file may include additional options depending on your
+Contents of the/etc/hosts.deny  file may include additional options depending on your
 network configuration.
 
 
@@ -2733,24 +2697,18 @@ network configuration.
 3.4.4 Ensure permissions on /etc/hosts.allow are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/hosts.allow file contains networking information that is used by many
+The /etc/hosts.allow  file contains networking information that is used by many
 applications and therefore must be readable for these applications to operate.
 Rationale:
-It is critical to ensure that the /etc/hosts.allow file is protected from unauthorized write
+It is critical to ensure that /etc/hosts.allow  file is protected from unauthorized write
 access. Although it is protected by default, the file permissions could be changed either
 inadvertently or through malicious actions.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 644:
+Run the following command and verify  Uid and Gid are both 0/root and Access is644 :
 # stat /etc/hosts.allow
-Access: (0644/-rw-r--r--)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0644/-rw-r--r--)  Uid: (   0/  root)  Gid: (   0/  root)
 Remediation:
-Run the following commands to set permissions on /etc/hosts.allow:
+Run the following commands to set permissions on  /etc/hosts.allow :
 # chown root:root /etc/hosts.allow
 # chmod 644 /etc/hosts.allow
 
@@ -2759,24 +2717,17 @@ Run the following commands to set permissions on /etc/hosts.allow:
 3.4.5 Ensure permissions on /etc/hosts.deny are 644 (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/hosts.deny file contains network information that is used by many system
+The /etc/hosts.deny  file contains network information that is used by many system
 applications and therefore must be readable for these applications to operate.
 Rationale:
-It is critical to ensure that the /etc/hosts.deny file is protected from unauthorized write
+It is critical to ensure that /etc/hosts.deny  file is protected from unauthorized write
 access. Although it is protected by default, the file permissions could be changed either
 inadvertently or through malicious actions.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 644:
-# stat /etc/hosts.deny
-Access: (0644/-rw-r--r--)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Run the following command and verify  Uid and Gid are both 0/root and Access is644 :
+Access: (0644/-rw-r--r--)  Uid: (   0/  root)  Gid: (   0/  root)
 Remediation:
-Run the following commands to set permissions on /etc/hosts.deny:
+Run the following commands to set permissions on  /etc/hosts.deny :
 # chown root:root /etc/hosts.deny
 # chmod 644 /etc/hosts.deny
 
@@ -2791,7 +2742,8 @@ Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 The Datagram Congestion Control Protocol (DCCP) is a transport layer protocol that
 supports streaming media and telephony. DCCP provides a way to gain access to
-congestion control, without having to do it at the application layer, but does not provide insequence delivery.
+congestion control, without having to do it at the application layer, but does not provide in-
+sequence delivery.
 Rationale:
 If the protocol is not required, it is recommended that the drivers not be installed
 to reduce the potential attack surface.
@@ -2802,7 +2754,7 @@ install /bin/true
 # lsmod | grep dccp
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fi/etc/modprobe.d/CIS.conf   and add the following line:
 install dccp /bin/true
 
 
@@ -2825,7 +2777,7 @@ install /bin/true
 # lsmod | grep sctp
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fil/etc/modprobe.d/CIS.conf   and add the following line:
 install sctp /bin/true
 
 
@@ -2846,7 +2798,7 @@ install /bin/true
 # lsmod | grep rds
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fi/etc/modprobe.d/CIS.conf   and add the following line:
 install rds /bin/true
 
 
@@ -2866,7 +2818,7 @@ install /bin/true
 # lsmod | grep tipc
 <No output>
 Remediation:
-Edit or create the file /etc/modprobe.d/CIS.conf and add the following line:
+Edit or create the fi/etc/modprobe.d/CIS.conf   and add the following line:
 install tipc /bin/true
 
 3.6 Firewall Configuration
@@ -2876,7 +2828,7 @@ configuration exist this section is intended only to ensure the resulting IPtabl
 place, not how they are configured. If IPv6 is in use in your environment, similar settings
 should be applied to the IP6tables as well.
 Note: This section broadly assumes starting with an empty IPtables firewall ruleset
-(established by flushing the rules with iptables -F). Remediation steps included only
+(established by flushing the rules withiptables -F ). Remediation steps included only
 affect the live system, you will also need to configure your default firewall configuration to
 apply on boot. Configuration of a live systems firewall directly over a remote connection
 will often result in being locked out. It is advised to have a known good firewall
@@ -2886,36 +2838,20 @@ firewall rules of this section and open port 22(ssh) from anywhere:
 #!/bin/bash
 # Flush IPtables rules
 iptables -F
-# Ensure
-iptables
-iptables
-iptables
-default deny firewall policy
--P INPUT DROP
--P OUTPUT DROP
--P FORWARD DROP
-# Ensure
-iptables
-iptables
-iptables
-loopback traffic is configured
--A INPUT -i lo -j ACCEPT
--A OUTPUT -o lo -j ACCEPT
--A INPUT -s 127.0.0.0/8 -j DROP
-# Ensure
-iptables
-iptables
-iptables
-iptables
-iptables
-iptables
-outbound and established connections are configured
--A OUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT
--A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT
--A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT
--A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT
--A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT
--A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT
+# Ensure default deny firewall policy
+iptables -P OUTPUT DROP
+iptables -P FORWARD DROP
+# Ensure loopback traffic is configured
+iptables -A INPUT -i lo -j ACCEPT
+iptables -A OUTPUT -o lo -j ACCEPT
+iptables -A INPUT -s 127.0.0.0/8 -j DROP
+# Ensure outbound and established connections are configured
+iptables -A OUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT
+iptables -A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT
+iptables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT
+iptables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT
 # Open inbound ssh(tcp port 22) connections
 iptables -A INPUT -p tcp --dport 22 -m state --state NEW -j ACCEPT
 Ubuntu is distributed with the UFW service which acts as a front end to iptables. The
@@ -2929,14 +2865,14 @@ strictly matching the examples provided. Note: UFW may interfere with sysctl set
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 iptables allows configuration of the IPv4 tables in the linux kernel and the rules stored
-within them. Most firewall configuration utilities operate as a front end to iptables.
+within them. Most firewall configuration utilities operate as a front end to iptables .
 Rationale:
 iptables is required for firewall management and configuration.
 Audit:
 Run the following command and verify iptables is installed:
 # dpkg -s iptables
 Remediation:
-Run the following command to install iptables:
+Run the following command to install  iptables :
 # apt-get install iptables
 
 
@@ -2950,8 +2886,8 @@ Rationale:
 With a default accept policy the firewall will accept any packet that is not configured to be
 denied. It is easier to white list acceptable usage than to black list unacceptable usage.
 Audit:
-Run the following command and verify that the policy for the INPUT, OUTPUT, and FORWARD
-chains is DROP or REJECT:
+Run the following command and verify that the policy for the INPUT ,OUTPUT , and FORWARD
+chains isDROP orREJECT :
 # iptables -L
 Chain INPUT (policy DROP)
 Chain FORWARD (policy DROP)
@@ -2984,36 +2920,13 @@ Run the following commands and verify output includes the listed rules in order 
 and byte counts may differ):
 # iptables -L INPUT -v -n
 Chain INPUT (policy DROP 0 packets, 0 bytes)
-pkts bytes target
-prot opt in
-out
-0
-0 ACCEPT
-all -- lo
-*
-0
-0 DROP
-all -- *
-*
-source
-0.0.0.0/0
-127.0.0.0/8
-destination
-0.0.0.0/0
-0.0.0.0/0
+pkts bytes target   prot opt in   out   source        destination
+0   0 ACCEPT   all --  lo   *    0.0.0.0/0       0.0.0.0/0
+0   0 DROP    all --  *   *    127.0.0.0/8      0.0.0.0/0
 # iptables -L OUTPUT -v -n
 Chain OUTPUT (policy DROP 0 packets, 0 bytes)
-pkts bytes target
-prot opt in
-out
-0
-0 ACCEPT
-all -- *
-lo
-source
-0.0.0.0/0
-destination
-0.0.0.0/0
+pkts bytes target   prot opt in   out   source        destination
+0   0 ACCEPT   all --  *   lo   0.0.0.0/0       0.0.0.0/0
 Remediation:
 Run the following commands to implement the loopback rules:
 # iptables -A INPUT -i lo -j ACCEPT
@@ -3043,30 +2956,12 @@ connections match site policy:
 Remediation:
 Configure iptables in accordance with site policy. The following commands will implement
 a policy to allow all outbound connections and all established connections:
-#
-#
-#
-#
-#
-#
-iptables
-iptables
-iptables
-iptables
-iptables
-iptables
--A
--A
--A
--A
--A
--A
-OUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT
-OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT
-OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT
-INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT
-INPUT -p udp -m state --state ESTABLISHED -j ACCEPT
-INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT
+# iptables -A OUTPUT -p tcp -m state --state NEW,ESTABLISHED -j ACCEPT
+# iptables -A OUTPUT -p udp -m state --state NEW,ESTABLISHED -j ACCEPT
+# iptables -A OUTPUT -p icmp -m state --state NEW,ESTABLISHED -j ACCEPT
+# iptables -A INPUT -p tcp -m state --state ESTABLISHED -j ACCEPT
+# iptables -A INPUT -p udp -m state --state ESTABLISHED -j ACCEPT
+# iptables -A INPUT -p icmp -m state --state ESTABLISHED -j ACCEPT
 Notes:
 Changing firewall settings while connected over network can result in being locked out of
 the system.
@@ -3087,41 +2982,16 @@ Audit:
 Run the following command to determine open ports:
 # netstat -ln
 Active Internet connections (only servers)
-Proto Recv-Q Send-Q Local Address
-tcp
-0
-0 0.0.0.0:22
-Foreign Address
-0.0.0.0:*
-State
-LISTEN
+Proto Recv-Q Send-Q Local Address       Foreign Address     State
+tcp     0   0 0.0.0.0:22        0.0.0.0:*        LISTEN
 Run the following command to determine firewall rules:
 # iptables -L INPUT -v -n
 Chain INPUT (policy DROP 0 packets, 0 bytes)
-pkts bytes target
-prot opt in
-out
-0
-0 ACCEPT
-all -- lo
-*
-0
-0 DROP
-all -- *
-*
-0
-0 ACCEPT
-tcp -- *
-*
+pkts bytes target   prot opt in   out   source        destination
+0   0 ACCEPT   all --  lo   *    0.0.0.0/0       0.0.0.0/0
+0   0 DROP    all --  *   *    127.0.0.0/8      0.0.0.0/0
+0   0 ACCEPT   tcp --  *   *    0.0.0.0/0       0.0.0.0/0
 tcp dpt:22 state NEW
-source
-0.0.0.0/0
-127.0.0.0/8
-0.0.0.0/0
-destination
-0.0.0.0/0
-0.0.0.0/0
-0.0.0.0/0
 Verify all open ports listening on non-localhost addresses have at least one firewall rule.
 The last line identified by the "tcp dpt:22 state NEW" identifies it as a firewall rule for new
 connections on tcp port 22.
@@ -3160,12 +3030,46 @@ Disable any wireless interfaces in your network configuration.
 Impact:
 Many if not all laptop workstations and some desktop workstations will connect via
 wireless requiring these interfaces be enabled.
+4 Logging and Auditing
+The items in this section describe how to configure logging, log monitoring, and auditing,
+using tools included in most distributions.
+It is recommended that rsyslog be used for logging (withlogwatch providing
+summarization) and auditd be used for auditing (witaureport providing
+
+summarization) to automatically monitor logs for intrusion attempts and other suspicious
+system behavior.
+In addition to the local log files created by the steps in this section, it is also recommended
+that sites collect copies of their system logs on a secure, centralized log server via an
+encrypted connection. Not only does centralized logging help sites correlate events that
+may be occurring on multiple systems, but having a second copy of the system log
+information may be critical after a system compromise where the attacker has modified the
+local log files on the affected system(s). If a log correlation system is deployed, configure it
+to process the logs described in this section.
+Because it is often necessary to correlate log information from many different systems
+(particularly after a security incident) it is recommended that the time be synchronized
+among systems and devices connected to the local network. The standard Internet protocol
+for time synchronization is the Network Time Protocol (NTP), which is supported by most
+network-ready devices. See the ntpd(8) manual page for more information on configuring
+NTP.
+It is important that all logs described in this section be monitored on a regular basis and
+correlated to determine trends. A seemingly innocuous entry in one log could be more
+significant when compared to an entry in another log.
+Note on log file permissions: There really isn't a "one size fits all" solution to the
+permissions on log files. Many sites utilize group permissions so that administrators who
+are in a defined security group, such as "wheel" do not have to elevate privileges to root in
+order to read log files. Also, if a third party log aggregation tool is used, it may need to have
+group permissions to read the log files, which is preferable to having it run setuid to root.
+Therefore, there are two remediation and audit steps for log file permissions. One is for
+systems that do not have a secured group method implemented that only permits root to
+read the log filesroot:root 600  ). The other is for sites that do have such a setup and are
+designated as root:securegrp 640   where securegrp  is the defined security group (in
+some cases wheel ).
 
 4.1 Configure System Accounting (auditd)
-System auditing, through auditd, allows system administrators to monitor their systems
+System auditing, through auditd , allows system administrators to monitor their systems
 such that they can detect unauthorized access or modification of data. By default, auditd
 will audit SELinux AVC denials, system logins, account modifications, and authentication
-events. Events will be logged to /var/log/audit/audit.log. The recording of these events
+events. Events will be logged to/var/log/audit/audit.log   . The recording of these events
 will use a modest amount of disk space on a system. If significantly more events are
 captured, additional on system or off system storage may need to be allocated.
 
@@ -3174,7 +3078,7 @@ quantities of logged data. In some environments it can be challenging to store o
 these logs and as such they are marked as Level 2 for both Servers and Workstations.
 Note: For 64 bit systems that have arch as a rule parameter, you will need two rules: one
 for 64 bit and one for 32 bit systems. For 32 bit systems, only one rule is needed.
-Note: Once all configuration changes have been made to /etc/audit/audit.rules, the
+Note: Once all configuration changes have been made to   /etc/audit/audit.rules  , the
 auditd configuration must be reloaded:
 # service auditd reload
 
@@ -3198,7 +3102,7 @@ Run the following command and ensure output is in compliance with site policy:
 # grep max_log_file /etc/audit/auditd.conf
 max_log_file = <MB>
 Remediation:
-Set the following parameter in /etc/audit/auditd.conf in accordance with site policy:
+Set the following parameter in /etc/audit/auditd.conf  in accordance with site policy:
 max_log_file = <MB>
 Notes:
 The max_log_file parameter is measured in megabytes.
@@ -3214,14 +3118,13 @@ In high security contexts, the risk of detecting unauthorized access or nonrepud
 exceeds the benefit of the system's availability.
 Audit:
 Run the following commands and verify output matches:
-# grep space_left_action /etc/audit/auditd.conf
-space_left_action = email
+space_left_action = email/etc/audit/auditd.conf
 # grep action_mail_acct /etc/audit/auditd.conf
 action_mail_acct = root
 # grep admin_space_left_action /etc/audit/auditd.conf
 admin_space_left_action = halt
 Remediation:
-Set the following parameters in /etc/audit/auditd.conf:
+Set the following parameters in/etc/audit/auditd.conf:
 space_left_action = email
 action_mail_acct = root
 admin_space_left_action = halt
@@ -3231,8 +3134,8 @@ admin_space_left_action = halt
 4.1.1.3 Ensure audit logs are not automatically deleted (Scored)
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
-The max_log_file_action setting determines how to handle the audit log file reaching the
-max file size. A value of keep_logs will rotate the logs but never delete old logs.
+The max_log_file_action  setting determines how to handle the audit log file reaching the
+max file size. A value okeep_logs will rotate the logs but never delete old logs.
 Rationale:
 In high security contexts, the benefits of maintaining a long audit history exceed the cost of
 storing the audit history.
@@ -3241,7 +3144,7 @@ Run the following command and verify output matches:
 # grep max_log_file_action /etc/audit/auditd.conf
 max_log_file_action = keep_logs
 Remediation:
-Set the following parameter in /etc/audit/auditd.conf:
+Set the following parameter in/etc/audit/auditd.conf:
 max_log_file_action = keep_logs
 
 
@@ -3255,11 +3158,10 @@ The capturing of system events provides system administrators with information t
 them to determine if unauthorized access to their system is occurring.
 Audit:
 Run the following command to verify auditd is enabled:
-# systemctl is-enabled auditd
-enabled
+enabledmctl is-enabled auditd
 Verify result is "enabled".
 Remediation:
-Run the following command to enable auditd:
+Run the following command to enable  auditd :
 # systemctl enable auditd
 
 
@@ -3269,17 +3171,17 @@ Run the following command to enable auditd:
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
 Configure grub so that processes that are capable of being audited can be audited even if
-they start up prior to auditd startup.
+they start up prior tauditd startup.
 Rationale:
-Audit events need to be captured on processes that start up prior to auditd, so that
+Audit events need to be captured on processes that start up prior tauditd , so that
 potential malicious activity cannot go undetected.
 Audit:
-Run the following command and verify that each linux line has the audit=1 parameter set:
+Run the following command and verify that each linux line has theaudit=1 parameter set:
 # grep "^\s*linux" /boot/grub/grub.cfg
 Remediation:
-Edit /etc/default/grub and add audit=1 to GRUB_CMDLINE_LINUX:
+Edit /etc/default/grub  and add audit=1 to GRUB_CMDLINE_LINUX:
 GRUB_CMDLINE_LINUX="audit=1"
-Run the following command to update the grub2 configuration:
+Run the following command to update the  grub2 configuration:
 # update-grub
 Notes:
 This recommendation is designed around the grub bootloader, if LILO or another
@@ -3292,17 +3194,16 @@ bootloader is in use in your environment enact equivalent settings.
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
 Capture events where the system date and/or time has been modified. The parameters in
-this section are set to determine if the adjtimex (tune kernel clock), settimeofday (Set
+this section are set to determine if tadjtimex (tune kernel clock),settimeofday  (Set
 time, using timeval and timezone structures) stime (using seconds since 1/1/1970) or
-clock_settime (allows for the setting of several internal clocks and timers) system calls
-have been executed and always write an audit record to the /var/log/audit.log file upon
+clock_settime  (allows for the setting of several internal clocks and timers) system calls
+have been executed and always write an audit record to the /var/log/audit.log  file upon
 exit, tagging the records with the identifier "time-change"
 Rationale:
 Unexpected changes in system date and/or time could be a sign of malicious activity on the
 system.
 Audit:
 On a 32 bit system run the following command and verify the output matches:
-# grep time-change /etc/audit/audit.rules
 -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
 -a always,exit -F arch=b32 -S clock_settime -k time-change
 -w /etc/localtime -p wa -k time-change
@@ -3314,32 +3215,17 @@ On a 64 bit system run the following command and verify the output matches:
 -a always,exit -F arch=b32 -S clock_settime -k time-change
 -w /etc/localtime -p wa -k time-change
 Remediation:
-For 32 bit systems add the following lines to the /etc/audit/audit.rules file:
+For 32 bit systems add the following lines to th/etc/audit/audit.rules  file:
 
 -a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
 -a always,exit -F arch=b32 -S clock_settime -k time-change
 -w /etc/localtime -p wa -k time-change
-For 64 bit systems add the following lines to the /etc/audit/audit.rules file:
--a
--a
--a
--a
--w
-always,exit -F
-always,exit -F
-always,exit -F
-always,exit -F
-/etc/localtime
-arch=b64
-arch=b32
-arch=b64
-arch=b32
--p wa -k
--S adjtimex -S settimeofday -k time-change
--S adjtimex -S settimeofday -S stime -k time-change
--S clock_settime -k time-change
--S clock_settime -k time-change
-time-change
+For 64 bit systems add the following lines to the/etc/audit/audit.rules   file:
+-a always,exit -F arch=b64 -S adjtimex -S settimeofday -k time-change
+-a always,exit -F arch=b32 -S adjtimex -S settimeofday -S stime -k time-change
+-a always,exit -F arch=b64 -S clock_settime -k time-change
+-a always,exit -F arch=b32 -S clock_settime -k time-change
+-w /etc/localtime -p wa -k time-change
 
 
 
@@ -3347,8 +3233,8 @@ time-change
 (Scored)
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
-Record events affecting the group, passwd (user IDs), shadow and gshadow (passwords) or
-/etc/security/opasswd (old passwords, based on remember parameter in the PAM
+Record events affecting the group,passwd  (user IDs),shadow and gshadow (passwords) or
+/etc/security/opasswd   (old passwords, based on remember parameter in the PAM
 configuration) files. The parameters in this section will watch the files to see if they have
 been opened for write or have had attribute changes (e.g. permissions) and tag them with
 the identifier "identity" in the audit log file.
@@ -3365,17 +3251,12 @@ Run the following command and verify output matches:
 -w /etc/shadow -p wa -k identity
 -w /etc/security/opasswd -p wa -k identity
 Remediation:
-Add the following lines to the /etc/audit/audit.rules file:
--w
--w
--w
--w
--w
-/etc/group -p wa -k identity
-/etc/passwd -p wa -k identity
-/etc/gshadow -p wa -k identity
-/etc/shadow -p wa -k identity
-/etc/security/opasswd -p wa -k identity
+Add the following lines to the/etc/audit/audit.rules   file:
+-w /etc/group -p wa -k identity
+-w /etc/passwd -p wa -k identity
+-w /etc/gshadow -p wa -k identity
+-w /etc/shadow -p wa -k identity
+-w /etc/security/opasswd -p wa -k identity
 
 
 
@@ -3386,18 +3267,19 @@ Description:
 Record changes to network environment files or system calls. The below parameters
 monitor the sethostname (set the systems host name) or setdomainname (set the systems
 domainname) system calls, and write an audit event on system call exit. The other
-parameters monitor the /etc/issue and /etc/issue.net files (messages displayed prelogin), /etc/hosts (file containing host names and associated IP addresses) and
-/etc/sysconfig/network (directory containing network interface scripts and
+parameters monitor the /etc/issue  and /etc/issue.net  files (messages displayed pre-
+login),/etc/hosts (file containing host names and associated IP addresses) and
+/etc/sysconfig/network  (directory containing network interface scripts and
 configurations) files.
 Rationale:
-Monitoring sethostname and setdomainname will identify potential unauthorized changes
+Monitoring sethostname and setdomainname  will identify potential unauthorized changes
 to host and domainname of a system. The changing of these names could potentially break
 security parameters that are set based on those names. The /etc/hosts file is monitored
 for changes in the file that can indicate an unauthorized intruder is trying to change
 machine associations with IP addresses and trick users and processes into connecting to
-unintended machines. Monitoring /etc/issue and /etc/issue.net is important, as
+unintended machines. Monitoring  /etc/issue and /etc/issue.net  is important, as
 intruders could put disinformation into those files and trick users into providing
-information to the intruder. Monitoring /etc/sysconfig/network is important as it can
+information to the intruder. Monitoring/etc/sysconfig/network   is important as it can
 show if network interfaces or scripts are being modified in a way that can lead to the
 machine becoming unavailable or compromised. All audit records will be tagged with the
 identifier "system-locale."
@@ -3421,34 +3303,21 @@ On a 64 bit system run the following command and verify the output matches:
 -w /etc/network -p wa -k system-locale
 -w /etc/networks -p wa -k system-locale
 Remediation:
-For 32 bit systems add the following lines to the /etc/audit/audit.rules file:
--a
--w
--w
--w
--w
--w
-always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
-/etc/issue -p wa -k system-locale
-/etc/issue.net -p wa -k system-locale
-/etc/hosts -p wa -k system-locale
-/etc/network -p wa -k system-locale
-/etc/networks -p wa -k system-locale
-For 64 bit systems add the following lines to the /etc/audit/audit.rules file:
--a
--a
--w
--w
--w
--w
--w
-always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale
-always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
-/etc/issue -p wa -k system-locale
-/etc/issue.net -p wa -k system-locale
-/etc/hosts -p wa -k system-locale
-/etc/network -p wa -k system-locale
-/etc/networks -p wa -k system-locale
+For 32 bit systems add the following lines to the/etc/audit/audit.rules   file:
+-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
+-w /etc/issue -p wa -k system-locale
+-w /etc/issue.net -p wa -k system-locale
+-w /etc/hosts -p wa -k system-locale
+-w /etc/network -p wa -k system-locale
+-w /etc/networks -p wa -k system-locale
+For 64 bit systems add the following lines to the/etc/audit/audit.rules   file:
+-a always,exit -F arch=b64 -S sethostname -S setdomainname -k system-locale
+-a always,exit -F arch=b32 -S sethostname -S setdomainname -k system-locale
+-w /etc/issue -p wa -k system-locale
+-w /etc/issue.net -p wa -k system-locale
+-w /etc/hosts -p wa -k system-locale
+-w /etc/network -p wa -k system-locale
+-w /etc/networks -p wa -k system-locale
 
 
 
@@ -3472,9 +3341,9 @@ On systems using AppArmor run the following command and verify output matches:
 -w /etc/apparmor/ -p wa -k MAC-policy
 -w /etc/apparmor.d/ -p wa -k MAC-policy
 Remediation:
-On systems using SELinux add the following line to the /etc/audit/audit.rules file:
+On systems using SELinux add the following line to the /etc/audit/audit.rules  file:
 -w /etc/selinux/ -p wa -k MAC-policy
-On systems using AppArmor add the following line to the /etc/audit/audit.rules file:
+On systems using AppArmor add the following line to the /etc/audit/audit.rules  file:
 -w /etc/apparmor/ -p wa -k MAC-policy
 -w /etc/apparmor.d/ -p wa -k MAC-policy
 
@@ -3484,9 +3353,9 @@ On systems using AppArmor add the following line to the /etc/audit/audit.rules f
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
 Monitor login and logout events. The parameters below track changes to files associated
-with login/logout events. The file /var/log/faillog tracks failed events from login. The
-file /var/log/lastlog maintain records of the last time a user successfully logged in. The
-file /var/log/tallylog maintains records of failures via the pam_tally2 module
+with login/logout events. The file/var/log/faillog  tracks failed events from login. The
+file/var/log/lastlog  maintain records of the last time a user successfully logged in. The
+file/var/log/tallylog  maintains records of failures via thepam_tally2  module
 Rationale:
 Monitoring login/logout events could provide a system administrator with information
 associated with brute force attacks against user logins.
@@ -3497,9 +3366,8 @@ Run the following command and verify output matches:
 -w /var/log/lastlog -p wa -k logins
 -w /var/log/tallylog -p wa -k logins
 Remediation:
-Add the following lines to the /etc/audit/audit.rules file:
+Add the following lines to the/etc/audit/audit.rules   file:
 -w /var/log/faillog -p wa -k logins
--w /var/log/lastlog -p wa -k logins
 -w /var/log/tallylog -p wa -k logins
 
 
@@ -3508,11 +3376,11 @@ Add the following lines to the /etc/audit/audit.rules file:
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
 Monitor session initiation events. The parameters in this section track changes to the files
-associated with session events. The file /var/run/utmp file tracks all currently logged in
-users. The /var/log/wtmp file tracks logins, logouts, shutdown, and reboot events. All
-audit records will be tagged with the identifier "session." The file /var/log/btmp keeps
+associated with session events. The fil/var/run/utmp  file tracks all currently logged in
+users. The /var/log/wtmp  file tracks logins, logouts, shutdown, and reboot events. All
+audit records will be tagged with the identifier "session." The /var/log/btmp  keeps
 track of failed login attempts and can be read by entering the command /usr/bin/last -f
-/var/log/btmp. All audit records will be tagged with the identifier "logins."
+/var/log/btmp . All audit records will be tagged with the identifier "logins."
 Rationale:
 Monitoring these files for changes could alert a system administrator to logins occurring at
 unusual hours, which could indicate intruder activity (i.e. a user logging in at a time when
@@ -3524,13 +3392,13 @@ Run the following command and verify output matches:
 -w /var/log/wtmp -p wa -k session
 -w /var/log/btmp -p wa -k session
 Remediation:
-Add the following lines to the /etc/audit/audit.rules file:
+Add the following lines to th/etc/audit/audit.rules   file:
 -w /var/run/utmp -p wa -k session
 -w /var/log/wtmp -p wa -k session
 -w /var/log/btmp -p wa -k session
 Notes:
-The last command can be used to read /var/log/wtmp (last with no parameters)
-and /var/run/utmp (last -f /var/run/utmp)
+The last command can be used to read  /var/log/wtmp  (last with no parameters)
+and /var/run/utmp  (last -f /var/run/utmp  )
 
 
 
@@ -3540,10 +3408,10 @@ Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
 Monitor changes to file permissions, attributes, ownership and group. The parameters in
 this section track changes for system calls that affect file permissions and attributes. The
-chmod, fchmod and fchmodat system calls affect the permissions associated with a file. The
-chown, fchown, fchownat and lchown system calls affect owner and group attributes on a
-file. The setxattr, lsetxattr, fsetxattr (set extended file attributes) and removexattr,
-lremovexattr, fremovexattr (remove extended file attributes) control extended file
+chmod ,fchmod  and fchmodat system calls affect the permissions associated with a file. The
+chown ,fchown ,fchownat  and lchown system calls affect owner and group attributes on a
+file. Thesetxattr ,lsetxattr , fsetxattr  (set extended file attributes) andremovexattr  ,
+lremovexattr  ,fremovexattr  (remove extended file attributes) control extended file
 attributes. In all cases, an audit record will only be written for non-system user ids (auid >=
 1000) and will ignore Daemon events (auid = 4294967295). All audit records will be
 tagged with the identifier "perm_mod."
@@ -3554,7 +3422,6 @@ Audit:
 On a 32 bit system run the following command and verify the output matches:
 # grep perm_mod /etc/audit/audit.rules
 -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F
-auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F
 auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S
@@ -3575,14 +3442,14 @@ lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S
 lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
 Remediation:
-For 32 bit systems add the following lines to the /etc/audit/audit.rules file:
+For 32 bit systems add the following lines to the/etc/audit/audit.rules   file:
 -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F
 auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F
 auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S
 lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod
-For 64 bit systems add the following lines to the /etc/audit/audit.rules file:
+For 64 bit systems add the following lines to the/etc/audit/audit.rules   file:
 -a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F
 auid!=4294967295 -k perm_mod
 -a always,exit -F arch=b32 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F
@@ -3603,8 +3470,9 @@ collected (Scored)
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
 Monitor for unsuccessful attempts to access files. The parameters below are associated
-with system calls that control creation (creat), opening (open, openat) and truncation
-(truncate, ftruncate) of files. An audit log record will only be written if the user is a nonprivileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the
+with system calls that control creation creat ), opening (open ,openat ) and truncation
+(truncate , ftruncate ) of files. An audit log record will only be written if the user is a non-
+privileged user (auid > = 1000), is not a Daemon event (auid=4294967295) and if the
 system call returned EACCES (permission denied to the file) or EPERM (some other
 permanent error associated with the specific system call). All audit records will be tagged
 with the identifier "access."
@@ -3613,45 +3481,36 @@ Failed attempts to open, create or truncate files could be an indication that an
 process is trying to gain unauthorized access to the system.
 Audit:
 On a 32 bit system run the following command and verify the output matches:
-# grep access /etc/audit/audit.rules
 -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
 On a 64 bit system run the following command and verify the output matches:
 # grep access /etc/audit/audit.rules
--a always,exit -F arch=b64 -S creat -S open -S openat -S
+-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S creat -S open -S openat -S
+-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S creat -S open -S openat -S
+-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S creat -S open -S openat -S
+-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
-truncate -S ftruncate -F
-truncate -S ftruncate -F
-truncate -S ftruncate -F
-truncate -S ftruncate -F
 
 Remediation:
-For 32 bit systems add the following lines to the /etc/audit/audit.rules file:
+For 32 bit systems add the following lines to the/etc/audit/audit.rules   file:
 -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
 -a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
-For 64 bit systems add the following lines to the /etc/audit/audit.rules file:
--a always,exit -F arch=b64 -S creat -S open -S openat -S
+For 64 bit systems add the following lines to the/etc/audit/audit.rules   file:
+-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S creat -S open -S openat -S
+-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EACCES -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b64 -S creat -S open -S openat -S
+-a always,exit -F arch=b64 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
--a always,exit -F arch=b32 -S creat -S open -S openat -S
+-a always,exit -F arch=b32 -S creat -S open -S openat -S truncate -S ftruncate -F
 exit=-EPERM -F auid>=1000 -F auid!=4294967295 -k access
-truncate -S ftruncate -F
-truncate -S ftruncate -F
-truncate -S ftruncate -F
-truncate -S ftruncate -F
 
 
 
@@ -3669,41 +3528,40 @@ can be executed from on your system:
 # find <partition> -xdev \( -perm -4000 -o -perm -2000 \) -type f | awk '{print \
 "-a always,exit -F path=" $1 " -F perm=x -F auid>=1000 -F auid!=4294967295 \
 -k privileged" }'
-Verify all resulting lines are in the /etc/audit/audit.rules file.
+Verify all resulting lines are in /etc/audit/audit.rules   file.
 Remediation:
 To remediate this issue, the system administrator will have to execute a find command to
 locate all the privileged programs and then add an audit line for each one of them. The
 audit parameters associated with this are as follows:
--F path=" $1 " - will populate each file name found through the find command and
+-F path=" $1 "  - will populate each file name found through the find command and
 processed by awk.
 -F perm=x - will write an audit record if the file is executed.
--F auid>=1000 - will write a record if the user executing the command is not a privileged
+-F auid>=1000  - will write a record if the user executing the command is not a privileged
 user.
--F auid!= 4294967295 - will ignore Daemon events
+-F auid!= 4294967295  - will ignore Daemon events
 All audit records should be tagged with the identifier "privileged".
 
 Run the following command replacing <partition> with a list of partitions where programs
 can be executed from on your system:
-# find <partition> -xdev \( -perm -4000 -o -perm -2000 \) -type f | awk '{print \
-"-a always,exit -F path=" $1 " -F perm=x -F auid>=1000 -F auid!=4294967295 \
+"-a always,exit -F path=" $1 " -F perm=x -F auid>=1000 -F auid!=4294967295 \int \
 -k privileged" }'
-Add all resulting lines to the /etc/audit/audit.rules file.
+Add all resulting lines to the/etc/audit/audit.rules   file.
 
 
 
 4.1.13 Ensure successful file system mounts are collected (Scored)
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
-Monitor the use of the mount system call. The mount (and umount) system call controls the
+Monitor the use of themount system call. The mount (and umount ) system call controls the
 mounting and unmounting of file systems. The parameters below configure the system to
 create an audit record when the mount system call is used by a non-privileged user
 Rationale:
-It is highly unusual for a non privileged user to mount file systems to the system. While
+It is highly unusual for a non privileged user mount file systems to the system. While
 tracking mount commands gives the system administrator evidence that external media
 may have been mounted (based on a review of the source of the mount and confirming it's
 an external media type), it does not conclusively indicate that data was exported to the
 media. System administrators who wish to determine if data were exported, would also
-have to track successful open, creat and truncate system calls requiring write access to a
+have to track successfulopen ,creat and truncate  system calls requiring write access to a
 file under the mount point of the external media file system. This could give a fair
 indication that a write occurred. The only way to truly prove it, would be to track
 successful writes to the external media. Tracking write system calls could quickly fill up the
@@ -3715,13 +3573,12 @@ On a 32 bit system run the following command and verify the output matches:
 -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
 On a 64 bit system run the following command and verify the output matches:
 # grep mounts /etc/audit/audit.rules
--a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
 -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
 Remediation:
-For 32 bit systems add the following lines to the /etc/audit/audit.rules file:
+For 32 bit systems add the following lines to th/etc/audit/audit.rules   file:
 
 -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
-For 64 bit systems add the following lines to the /etc/audit/audit.rules file:
+For 64 bit systems add the following lines to the /etc/audit/audit.rules   file:
 -a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
 -a always,exit -F arch=b32 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts
 Notes:
@@ -3734,8 +3591,8 @@ to come from external media and this action still does not verify write (e.g. CD
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
 Monitor the use of system calls associated with the deletion or renaming of files and file
-attributes. This configuration statement sets up monitoring for the unlink (remove a file),
-unlinkat (remove a file attribute), rename (rename a file) and renameat (rename a file
+attributes. This configuration statement sets up monitoring for theunlink (remove a file),
+unlinkat  (remove a file attribute)rename (rename a file) and renameat (rename a file
 attribute) system calls and tags them with the identifier "delete".
 Rationale:
 Monitoring these calls from non-privileged users could provide a system administrator
@@ -3746,18 +3603,22 @@ altered.
 Audit:
 On a 32 bit system run the following command and verify the output matches:
 # grep delete /etc/audit/audit.rules
--a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -
+F auid!=4294967295 -k delete
 On a 64 bit system run the following command and verify the output matches:
 # grep delete /etc/audit/audit.rules
--a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 F auid!=4294967295 -k delete
+-a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -
+F auid!=4294967295 -k delete
+F auid!=4294967295 -k deleteS unlink -S unlinkat -S rename -S renameat -F auid>=1000 -
 Remediation:
-For 32 bit systems add the following lines to the /etc/audit/audit.rules file:
--a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 F auid!=4294967295 -k delete
+For 32 bit systems add the following lines to the/etc/audit/audit.rules   file:
+F auid!=4294967295 -k deleteS unlink -S unlinkat -S rename -S renameat -F auid>=1000 -
 
-For 64 bit systems add the following lines to the /etc/audit/audit.rules file:
--a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 F auid!=4294967295 -k delete
--a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 F auid!=4294967295 -k delete
+For 64 bit systems add the following lines to the /etc/audit/audit.rules   file:
+-a always,exit -F arch=b64 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -
+F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlink -S unlinkat -S rename -S renameat -F auid>=1000 -
+F auid!=4294967295 -k delete
 Notes:
 At a minimum, configure the audit system to collect file deletion events for all users and
 root.
@@ -3771,10 +3632,10 @@ Description:
 Monitor scope changes for system administrations. If the system has been properly
 configured to force system administrators to log in as themselves first and then use the
 sudo command to execute privileged commands, it is possible to monitor changes in scope.
-The file /etc/sudoers will be written to when the file or its attributes have changed. The
+The file/etc/sudoers  will be written to when the file or its attributes have changed. The
 audit records will be tagged with the identifier "scope."
 Rationale:
-Changes in the /etc/sudoers file can indicate that an unauthorized change has been made
+Changes in the /etc/sudoers  file can indicate that an unauthorized change has been made
 to scope of system administrator activity.
 Audit:
 Run the following command and verify output matches:
@@ -3782,7 +3643,7 @@ Run the following command and verify output matches:
 -w /etc/sudoers -p wa -k scope
 -w /etc/sudoers.d -p wa -k scope
 Remediation:
-Add the following line to the /etc/audit/audit.rules file:
+Add the following line to th/etc/audit/audit.rules   file:
 -w /etc/sudoers -p wa -k scope
 -w /etc/sudoers.d -p wa -k scope
 
@@ -3793,22 +3654,22 @@ Add the following line to the /etc/audit/audit.rules file:
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
 Monitor the sudo log file. If the system has been properly configured to disable the use of
-the su command and force all administrators to have to log in first and then use sudo to
+the su command and force all administrators to have to log in first and then ussudo to
 execute privileged commands, then all administrator commands will be logged to
-/var/log/sudo.log. Any time a command is executed, an audit event will be triggered as
-the /var/log/sudo.log file will be opened for write and the executed administration
+/var/log/sudo.log . Any time a command is executed, an audit event will be triggered as
+the /var/log/sudo.log  file will be opened for write and the executed administration
 command will be written to the log.
 Rationale:
-Changes in /var/log/sudo.log indicate that an administrator has executed a command or
+Changes in /var/log/sudo.log  indicate that an administrator has executed a command or
 the log file itself has been tampered with. Administrators will want to correlate the events
-written to the audit trail with the records written to /var/log/sudo.log to verify if
+written to the audit trail with the records written/var/log/sudo.log  to verify if
 unauthorized commands have been executed.
 Audit:
 Run the following command and verify output matches:
 # grep actions /etc/audit/audit.rules
 -w /var/log/sudo.log -p wa -k actions
 Remediation:
-Add the following lines to the /etc/audit/audit.rules file:
+Add the following lines to th/etc/audit/audit.rules   file:
 -w /var/log/sudo.log -p wa -k actions
 Notes:
 The system must be configured with su disabled (See Item 5.6 Ensure access to the su
@@ -3823,15 +3684,15 @@ Description:
 Monitor the loading and unloading of kernel modules. The programs insmod (install a
 kernel module), rmmod (remove a kernel module), and modprobe (a more sophisticated
 program to load and unload modules, as well as some other features) control loading and
-unloading of modules. The init_module (load a module) and delete_module (delete a
+unloading of modules. The init_module  (load a module) and delete_module  (delete a
 module) system calls control loading and unloading of modules. Any execution of the
 loading and unloading module programs and system calls will trigger an audit record with
 an identifier of "modules".
 Rationale:
-Monitoring the use of insmod, rmmod and modprobe could provide system administrators
+Monitoring the use ofinsmod ,rmmod and modprobe  could provide system administrators
 with evidence that an unauthorized user loaded or unloaded a kernel module, possibly
-compromising the security of the system. Monitoring of the init_module and
-delete_module system calls would reflect an unauthorized user attempting to use a
+compromising the security of the system. Monitoring of theinit_module  and
+delete_module  system calls would reflect an unauthorized user attempting to use a
 different program to load and unload modules.
 Audit:
 On a 32 bit system run the following command and verify the output matches:
@@ -3848,31 +3709,23 @@ On a 64 bit system run the following command and verify the output matches:
 -a always,exit arch=b64 -S init_module -S delete_module -k modules
 Remediation:
 
-For 32 bit systems add the following lines to the /etc/audit/audit.rules file:
--w
--w
--w
--a
-/sbin/insmod -p x -k modules
-/sbin/rmmod -p x -k modules
-/sbin/modprobe -p x -k modules
-always,exit arch=b32 -S init_module -S delete_module -k modules
-For 64 bit systems add the following lines to the /etc/audit/audit.rules file:
--w
--w
--w
--a
-/sbin/insmod -p x -k modules
-/sbin/rmmod -p x -k modules
-/sbin/modprobe -p x -k modules
-always,exit arch=b64 -S init_module -S delete_module -k modules
+For 32 bit systems add the following lines to the /etc/audit/audit.rules   file:
+-w /sbin/insmod -p x -k modules
+-w /sbin/rmmod -p x -k modules
+-w /sbin/modprobe -p x -k modules
+-a always,exit arch=b32 -S init_module -S delete_module -k modules
+For 64 bit systems add the following lines to the /etc/audit/audit.rules   file:
+-w /sbin/insmod -p x -k modules
+-w /sbin/rmmod -p x -k modules
+-w /sbin/modprobe -p x -k modules
+-a always,exit arch=b64 -S init_module -S delete_module -k modules
 
 
 
 4.1.18 Ensure the audit configuration is immutable (Scored)
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
-Set system audit so that audit rules cannot be modified with auditctl. Setting the flag "-e
+Set system audit so that audit rules cannot be modified withauditctl . Setting the flag "-e
 2" forces audit to be put in immutable mode. Audit changes can only be made on system
 reboot.
 Rationale:
@@ -3885,7 +3738,7 @@ Run the following command and verify output matches:
 # grep "^\s*[^#]" /etc/audit/audit.rules | tail -1
 -e 2
 Remediation:
-Add the following line to the end of the/etc/audit/audit.rules file.
+Add the following line to the end of th/etc/audit/audit.rules  file.
 -e 2
 4.2 Configure Logging
 Logging services should be configured to prevent information leaks and to aggregate logs
@@ -3894,17 +3747,17 @@ ease log analysis.
 
 4.2.1 Configure rsyslog
 The rsyslog software is recommended as a replacement for the syslogd daemon and
-provides improvements over syslogd, such as connection-oriented (i.e. TCP) transmission
+provides improvements over  syslogd , such as connection-oriented (i.e. TCP) transmission
 of logs, the option to log to database formats, and the encryption of log data en route to a
 central logging server.
-Note: This section only applies if rsyslog is installed on the system.
+Note: This section only applies irsyslog is installed on the system.
 
 4.2.1.1 Ensure rsyslog Service is enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 Once the rsyslog package is installed it needs to be activated.
 Rationale:
-If the rsyslog service is not activated the system may default to the syslogd service or lack
+If thersyslog service is not activated the system may default to tsyslogd service or lack
 logging instead.
 Audit:
 Run the following command to verify rsyslog is enabled:
@@ -3912,7 +3765,7 @@ Run the following command to verify rsyslog is enabled:
 enabled
 Verify result is "enabled".
 Remediation:
-Run the following command to enable rsyslog:
+Run the following command to enable  rsyslog :
 # systemctl enable rsyslog
 
 
@@ -3920,49 +3773,34 @@ Run the following command to enable rsyslog:
 4.2.1.2 Ensure logging is configured (Not Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/rsyslog.conf file specifies rules for logging and which files are to be used to log
+The /etc/rsyslog.conf  file specifies rules for logging and which files are to be used to log
 certain classes of messages.
 Rationale:
-A great deal of important security-related information is sent via rsyslog (e.g., successful
+A great deal of important security-related information is sent virsyslog (e.g., successful
 and failed su attempts, failed login attempts, root login attempts, etc.).
 Audit:
-Review the contents of the /etc/rsyslog.conf file to ensure appropriate logging is set. In
+Review the contents of the /etc/rsyslog.conf  file to ensure appropriate logging is set. In
 addition, run the following command and verify that the log files are logging information:
 # ls -l /var/log/
 Remediation:
-Edit the following lines in the /etc/rsyslog.conf file as appropriate for your
+Edit the following lines in th/etc/rsyslog.conf  file as appropriate for your
 environment:
-*.emerg
-mail.*
-mail.info
-mail.warning
-mail.err
-news.crit
-news.err
-news.notice
-*.=warning;*.=err
-*.crit
-*.*;mail.none;news.none
-local0,local1.*
-local2,local3.*
-local4,local5.*
-local6,local7.*
-:omusrmsg:*
--/var/log/mail
--/var/log/mail.info
--/var/log/mail.warn
-/var/log/mail.err
--/var/log/news/news.crit
--/var/log/news/news.err
--/var/log/news/news.notice
--/var/log/warn
-/var/log/warn
--/var/log/messages
--/var/log/localmessages
--/var/log/localmessages
--/var/log/localmessages
--/var/log/localmessages
-Run the following command to restart rsyslogd:
+*.emerg                  :omusrmsg:*
+mail.*                  -/var/log/mail
+mail.info                 -/var/log/mail.info
+mail.warning               -/var/log/mail.warn
+mail.err                  /var/log/mail.err
+news.crit                 -/var/log/news/news.crit
+news.err                 -/var/log/news/news.err
+news.notice                -/var/log/news/news.notice
+*.=warning;*.=err             -/var/log/warn
+*.crit                   /var/log/warn
+*.*;mail.none;news.none          -/var/log/messages
+local0,local1.*              -/var/log/localmessages
+local2,local3.*              -/var/log/localmessages
+local4,local5.*              -/var/log/localmessages
+local6,local7.*              -/var/log/localmessages
+Run the following command to restart rsyslogd :
 # pkill -HUP rsyslogd
 
 References:
@@ -3979,16 +3817,16 @@ Rationale:
 It is important to ensure that log files have the correct permissions to ensure that sensitive
 data is archived and protected.
 Audit:
-Run the following command and verify that $FileCreateMode is 0640 or more restrictive:
+Run the following command and verify that  $FileCreateMode  is0640 or more restrictive:
 # grep ^\$FileCreateMode /etc/rsyslog.conf
 Remediation:
-Edit the /etc/rsyslog.conf and set $FileCreateMode to 0640 or more restrictive:
+Edit the /etc/rsyslog.conf and set$FileCreateMode  to0640 or more restrictive:
 $FileCreateMode 0640
 References:
 1. See the rsyslog.conf(5) man page for more information.
 Notes:
 You should also ensure this is not overridden with less restrictive settings in
-any /etc/rsyslog.d/* conf file.
+any /etc/rsyslog.d/*  conf file.
 
 
 
@@ -3996,27 +3834,27 @@ any /etc/rsyslog.d/* conf file.
 (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The rsyslog utility supports the ability to send logs it gathers to a remote log host running
-syslogd(8) or to receive messages from remote hosts, reducing administrative overhead.
+The rsyslog  utility supports the ability to send logs it gathers to a remote log host running
+syslogd(8)  or to receive messages from remote hosts, reducing administrative overhead.
 Rationale:
 Storing log data on a remote host protects log integrity from local attacks. If an attacker
 gains root access on the local system, they could tamper with or remove log data that is
 stored on the local system
 Audit:
-Review the /etc/rsyslog.conf file and verify that logs are sent to a central host (where
+Review the /etc/rsyslog.conf  file and verify that logs are sent to a central host (where
 loghost.example.com is the name of your central log host):
 # grep "^*.*[^I][^I]*@" /etc/rsyslog.conf
 *.* @@loghost.example.com
 Remediation:
-Edit the /etc/rsyslog.conf file and add the following line (where loghost.example.com is
+Edit the/etc/rsyslog.conf  file and add the following line (where loghost.example.com is
 the name of your central log host).
 *.* @@loghost.example.com
-Run the following command to restart rsyslog:
+Run the following command to restart rsyslog :
 # pkill -HUP rsyslogd
 References:
 1. See the rsyslog.conf(5) man page for more information.
 Notes:
-The double "at" sign (@@) directs rsyslog to use TCP to send log messages to the server,
+The double "at" sign @@ ) directrsyslog  to use TCP to send log messages to the server,
 which is a more reliable transport mechanism than the default UDP protocol.
 
 
@@ -4025,9 +3863,9 @@ which is a more reliable transport mechanism than the default UDP protocol.
 designated log hosts. (Not Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-By default, rsyslog does not listen for log messages coming in from remote systems. The
-ModLoad tells rsyslog to load the imtcp.so module so it can listen over a network via
-TCP. The InputTCPServerRun option instructs rsyslogd to listen on the specified TCP
+By default,rsyslog does not listen for log messages coming in from remote systems. The
+ModLoad tellsrsyslog to load theimtcp.so  module so it can listen over a network via
+TCP. The InputTCPServerRun  option instructsrsyslogd  to listen on the specified TCP
 port.
 Rationale:
 The guidance in the section ensures that remote log hosts are configured to only accept
@@ -4043,32 +3881,33 @@ $ModLoad imtcp.so
 # grep '$InputTCPServerRun' /etc/rsyslog.conf
 $InputTCPServerRun 514
 Remediation:
-For hosts that are designated as log hosts, edit the /etc/rsyslog.conf file and uncomment or add the following lines:
+For hosts that are designated as log hosts, edit t/etc/rsyslog.conf  file and un-
+comment or add the following lines:
 $ModLoad imtcp.so
 $InputTCPServerRun 514
-For hosts that are not designated as log hosts, edit the /etc/rsyslog.conf file and
+For hosts that are not designated as log hosts, edit t/etc/rsyslog.conf  file and
 comment or remove the following lines:
 # $ModLoad imtcp.so
 # $InputTCPServerRun 514
 
-Run the following command to restart rsyslogd:
+Run the following command to restart  rsyslogd :
 # pkill -HUP rsyslogd
 References:
 1. See the rsyslog(8) man page for more information.
 
 4.2.2 Configure syslog-ng
-The syslog-ng software is recommended as a replacement for the syslogd daemon and
-provides improvements over syslogd, such as connection-oriented (i.e. TCP) transmission
+The syslog-ng software is recommended as a replacement for the  syslogd daemon and
+provides improvements over  syslogd , such as connection-oriented (i.e. TCP) transmission
 of logs, the option to log to database formats, and the encryption of log data en route to a
 central logging server.
-Note: This section only applies if syslog-ng is installed on the system.
+Note: This section only applies isyslog-ng is installed on the system.
 
 4.2.2.1 Ensure syslog-ng service is enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 Once the syslog-ng package is installed it needs to be activated.
 Rationale:
-If the syslog-ng service is not activated the system may default to the syslogd service or
+If thesyslog-ng service is not activated the system may default to thsyslogd service or
 lack logging instead.
 Audit:
 Run the following command to verify syslog-ng is enabled:
@@ -4076,7 +3915,7 @@ Run the following command to verify syslog-ng is enabled:
 enabled
 Verify result is "enabled".
 Remediation:
-Run the following command to enable syslog-ng:
+Run the following command to enable  syslog-ng :
 # update-rc.d syslog-ng enable
 
 
@@ -4084,63 +3923,37 @@ Run the following command to enable syslog-ng:
 4.2.2.2 Ensure logging is configured (Not Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/syslog-ng/syslog-ng.conf file specifies rules for logging and which files are to
+The /etc/syslog-ng/syslog-ng.conf   file specifies rules for logging and which files are to
 be used to log certain classes of messages.
 Rationale:
-A great deal of important security-related information is sent via syslog-ng (e.g.,
+A great deal of important security-related information is sent visyslog-ng (e.g.,
 successful and failed su attempts, failed login attempts, root login attempts, etc.).
 Audit:
-Review the contents of the /etc/syslog-ng/syslog-ng.conf file to ensure appropriate
+Review the contents of the /etc/syslog-ng/syslog-ng.conf   file to ensure appropriate
 logging is set. In addition, run the following command and ensure that the log files are
 logging information:
 # ls -l /var/log/
 Remediation:
-Edit the log lines in the /etc/syslog-ng/syslog-ng.conf file as appropriate for your
+Edit the log lines in t/etc/syslog-ng/syslog-ng.conf   file as appropriate for your
 environment:
-log { source(src);
-log { source(src);
-log { source(src);
-log { source(src);
-log { source(src);
-log { source(src);
-log { source(src);
-log { source(src);
-log { source(src);
-log { source(src);
+log { source(src); source(chroots); filter(f_console); destination(console); };
+log { source(src); source(chroots); filter(f_console); destination(xconsole); };
+log { source(src); source(chroots); filter(f_newscrit); destination(newscrit); };
+log { source(src); source(chroots); filter(f_newserr); destination(newserr); };
+log { source(src); source(chroots); filter(f_newsnotice); destination(newsnotice); };
+log { source(src); source(chroots); filter(f_mailinfo); destination(mailinfo); };
+log { source(src); source(chroots); filter(f_mailwarn); destination(mailwarn); };
+log { source(src); source(chroots); filter(f_mailerr);   destination(mailerr); };
+log { source(src); source(chroots); filter(f_mail); destination(mail); };
+log { source(src); source(chroots); filter(f_acpid); destination(acpid); flags(final);
 };
-log { source(src);
+log { source(src); source(chroots); filter(f_acpid_full); destination(devnull);
 flags(final); };
-log { source(src);
+log { source(src); source(chroots); filter(f_acpid_old); destination(acpid);
+log { source(src); source(chroots); filter(f_netmgm); destination(netmgm);
 flags(final); };
-log { source(src);
-flags(final); };
-log { source(src);
-log { source(src);
-source(chroots);
-source(chroots);
-source(chroots);
-source(chroots);
-source(chroots);
-source(chroots);
-source(chroots);
-source(chroots);
-source(chroots);
-source(chroots);
-filter(f_console); destination(console); };
-filter(f_console); destination(xconsole); };
-filter(f_newscrit); destination(newscrit); };
-filter(f_newserr); destination(newserr); };
-filter(f_newsnotice); destination(newsnotice); };
-filter(f_mailinfo); destination(mailinfo); };
-filter(f_mailwarn); destination(mailwarn); };
-filter(f_mailerr); destination(mailerr); };
-filter(f_mail); destination(mail); };
-filter(f_acpid); destination(acpid); flags(final);
-source(chroots); filter(f_acpid_full); destination(devnull);
-source(chroots); filter(f_acpid_old); destination(acpid);
-source(chroots); filter(f_netmgm); destination(netmgm);
-source(chroots); filter(f_local); destination(localmessages); };
-source(chroots); filter(f_messages); destination(messages); };
+log { source(src); source(chroots); filter(f_local); destination(localmessages); };
+log { source(src); source(chroots); filter(f_messages); destination(messages); };
 
 log { source(src); source(chroots); filter(f_iptables); destination(firewall); };
 log { source(src); source(chroots); filter(f_warn); destination(warn); };
@@ -4158,14 +3971,14 @@ syslog-ng will create logfiles that do not already exist on the system. This set
 what permissions will be applied to these newly created files.
 Rationale:
 It is important to ensure that log files exist and have the correct permissions to ensure that
-sensitive syslog-ng data is archived and protected.
+sensitivesyslog-ng data is archived and protected.
 Audit:
-Run the following command and verify the perm option is 0640 or more restrictive:
+Run the following command and verify the  perm option is0640 or more restrictive:
 # grep ^options /etc/syslog-ng/syslog-ng.conf
 options { chain_hostnames(off); flush_lines(0); perm(0640); stats_freq(3600);
 threaded(yes); };
 Remediation:
-Edit the /etc/syslog-ng/syslog-ng.conf and set perm option to 0640 or more restrictive:
+Edit the/etc/syslog-ng/syslog-ng.conf   and set perm option to 0640 or more restrictive:
 options { chain_hostnames(off); flush_lines(0); perm(0640); stats_freq(3600);
 threaded(yes); };
 References:
@@ -4177,19 +3990,19 @@ References:
 (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The syslog-ng utility supports the ability to send logs it gathers to a remote log host or to
+The syslog-ng  utility supports the ability to send logs it gathers to a remote log host or to
 receive messages from remote hosts, reducing administrative overhead.
 Rationale:
 Storing log data on a remote host protects log integrity from local attacks. If an attacker
 gains root access on the local system, they could tamper with or remove log data that is
 stored on the local system
 Audit:
-Review the /etc/syslog-ng/syslog-ng.conf file and verify that logs are sent to a central
+Review the /etc/syslog-ng/syslog-ng.conf   file and verify that logs are sent to a central
 host (where logfile.example.com is the name of your central log host):
 destination logserver { tcp("logfile.example.com" port(514)); };
 log { source(src); destination(logserver); };
 Remediation:
-Edit the /etc/syslog-ng/syslog-ng.conf file and add the following lines (where
+Edit the/etc/syslog-ng/syslog-ng.conf   file and add the following lines (where
 logfile.example.com is the name of your central log host).
 destination logserver { tcp("logfile.example.com" port(514)); };
 log { source(src); destination(logserver); };
@@ -4204,10 +4017,10 @@ References:
 designated log hosts (Not Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-By default, syslog-ng does not listen for log messages coming in from remote systems.
+By default,syslog-ng  does not listen for log messages coming in from remote systems.
 Rationale:
 The guidance in the section ensures that remote log hosts are configured to only accept
-syslog-ng data from hosts within the specified domain and that those systems that are not
+syslog-ng  data from hosts within the specified domain and that those systems that are not
 designed to be log hosts do not accept any remote syslog-ng messages. This provides
 protection from spoofed log data and ensures that system administrators are reviewing
 reasonably complete syslog data in a central location.
@@ -4218,14 +4031,14 @@ source net{ tcp(); };
 destination remote { file("/var/log/remote/${FULLHOST}-log"); };
 log { source(net); destination(remote); };
 Remediation:
-On designated log hosts edit the /etc/syslog-ng/syslog-ng.conf file and configure the
+On designated log hosts edit the/etc/syslog-ng/syslog-ng.conf   file and configure the
 following lines are appropriately:
 source net{ tcp(); };
 destination remote { file("/var/log/remote/${FULLHOST}-log"); };
 log { source(net); destination(remote); };
-On non designated log hosts edit the /etc/syslog-ng/syslog-ng.conf file and remove or
+On non designated log hosts edit the/etc/syslog-ng/syslog-ng.conf   file and remove or
 edit any sources that accept network sourced log messages.
-Run the following command to restart syslog-ng:
+Run the following command to restart syslog-ng :
 # pkill -HUP syslog-ng
 References:
 
@@ -4237,7 +4050,7 @@ References:
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 The rsyslog and syslog-ng software are recommended replacements to the original
-syslogd daemon which provide improvements over syslogd, such as connection-oriented
+syslogd daemon which provide improvements over  syslogd , such as connection-oriented
 (i.e. TCP) transmission of logs, the option to log to database formats, and the encryption of
 log data en route to a central logging server.
 Rationale:
@@ -4250,7 +4063,7 @@ use one of the following command groups may provide the needed information:
 # dpkg -s rsyslog
 # dpkg -s syslog-ng
 Remediation:
-Install rsyslog or syslog-ng using one of the following commands:
+Install rsyslog osyslog-ng using one of the following commands:
 # apt-get install rsyslog
 # apt-get install syslog-ng
 
@@ -4282,18 +4095,21 @@ Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 The system includes the capability of rotating log files regularly to avoid filling up the
 system with logs or making the logs unmanageable large. The file
-/etc/logrotate.d/syslog is the configuration file used to rotate log files created by
-syslog or rsyslog.
+/etc/logrotate.d/syslog   is the configuration file used to rotate log files created by
+syslog or rsyslog .
 Rationale:
 By keeping the log files smaller and more manageable, a system administrator can easily
 archive these files to another system and spend less time looking through inordinately
 large log files.
 Audit:
-Review /etc/logrotate.conf and /etc/logrotate.d/* and verify logs are rotated
+Review /etc/logrotate.conf  and /etc/logrotate.d/  * and verify logs are rotated
 according to site policy.
 Remediation:
-Edit /etc/logrotate.conf and /etc/logrotate.d/* to ensure logs are rotated according
+Edit /etc/logrotate.conf  and /etc/logrotate.d/ * to ensure logs are rotated according
 to site policy.
+5 Access, Authentication and Authorization
+
+
 
 5.1 Configure cron
 
@@ -4303,7 +4119,7 @@ Description:
 The cron daemon is used to execute batch jobs on the system.
 Rationale:
 While there may not be user jobs that need to be run on the system, the system does have
-maintenance jobs that may include security monitoring that have to run, and cron is used
+maintenance jobs that may include security monitoring that have to run, andcron is used
 to execute them.
 Audit:
 Run the following command to verify cron is enabled:
@@ -4311,7 +4127,7 @@ Run the following command to verify cron is enabled:
 enabled
 Verify result is "enabled".
 Remediation:
-Run the following command to enable cron:
+Run the following command to enable cron :
 # systemctl enable crond
 
 
@@ -4319,7 +4135,7 @@ Run the following command to enable cron:
 5.1.2 Ensure permissions on /etc/crontab are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/crontab file is used by cron to control its own jobs. The commands in this item
+The /etc/crontab  file is used bcron to control its own jobs. The commands in this item
 make sure that root is the user and group owner of the file and that only the owner can
 access the file.
 Rationale:
@@ -4328,18 +4144,12 @@ files could provide unprivileged users with the ability to elevate their privile
 access to these files could provide users with the ability to gain insight on system jobs that
 run on the system and could provide them a way to gain unauthorized privileged access.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access does not
+Run the following command and verify Uid and Gid are both0/root and Access does not
 grant permissions to group or other:
 # stat /etc/crontab
-Access: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------)  Uid: (  0/  root)  Gid: (  0/  root)
 Remediation:
-Run the following commands to set ownership and permissions on /etc/crontab:
+Run the following commands to set ownership and permissions on  /etc/crontab :
 # chown root:root /etc/crontab
 # chmod og-rwx /etc/crontab
 
@@ -4359,18 +4169,12 @@ means for gaining unauthorized elevated privileges. Granting read access to this
 could give an unprivileged user insight in how to gain elevated privileges or circumvent
 auditing controls.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access does not
-grant permissions to group or other:
+Run the following command and verify  Uid and Gid are both 0/root and Access does not
+grant permissions to group or other :
 # stat /etc/cron.hourly
-Access: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------)  Uid: (   0/  root)  Gid: (   0/  root)
 Remediation:
-Run the following commands to set ownership and permissions on /etc/cron.hourly:
+Run the following commands to set ownership and permissions on  /etc/cron.hourly  :
 # chown root:root /etc/cron.hourly
 # chmod og-rwx /etc/cron.hourly
 
@@ -4379,8 +4183,8 @@ Run the following commands to set ownership and permissions on /etc/cron.hourly:
 5.1.4 Ensure permissions on /etc/cron.daily are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/cron.daily directory contains system cron jobs that need to run on a daily
-basis. The files in this directory cannot be manipulated by the crontab command, but are
+The /etc/cron.daily  directory contains system cron jobs that need to run on a daily
+basis. The files in this directory cannot be manipulated by tcrontab command, but are
 instead edited by system administrators using a text editor. The commands below restrict
 read/write and search access to user and group root, preventing regular users from
 accessing this directory.
@@ -4390,18 +4194,12 @@ means for gaining unauthorized elevated privileges. Granting read access to this
 could give an unprivileged user insight in how to gain elevated privileges or circumvent
 auditing controls.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access does not
+Run the following command and verify Uid and Gid are both0/root and Access does not
 grant permissions to group or other:
 # stat /etc/cron.daily
-Access: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------)  Uid: (  0/  root)  Gid: (  0/  root)
 Remediation:
-Run the following commands to set ownership and permissions on /etc/cron.daily:
+Run the following commands to set ownership and permissions on  /etc/cron.daily :
 # chown root:root /etc/cron.daily
 # chmod og-rwx /etc/cron.daily
 
@@ -4410,8 +4208,8 @@ Run the following commands to set ownership and permissions on /etc/cron.daily:
 5.1.5 Ensure permissions on /etc/cron.weekly are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/cron.weekly directory contains system cron jobs that need to run on a weekly
-basis. The files in this directory cannot be manipulated by the crontab command, but are
+The /etc/cron.weekly  directory contains system cron jobs that need to run on a weekly
+basis. The files in this directory cannot be manipulated by tcrontab command, but are
 instead edited by system administrators using a text editor. The commands below restrict
 read/write and search access to user and group root, preventing regular users from
 accessing this directory.
@@ -4421,18 +4219,12 @@ means for gaining unauthorized elevated privileges. Granting read access to this
 could give an unprivileged user insight in how to gain elevated privileges or circumvent
 auditing controls.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access does not
+Run the following command and verify Uid and Gid are both0/root and Access does not
 grant permissions to group or other:
 # stat /etc/cron.weekly
-Access: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------)  Uid: (  0/  root)  Gid: (  0/  root)
 Remediation:
-Run the following commands to set ownership and permissions on /etc/cron.weekly:
+Run the following commands to set ownership and permissions on  /etc/cron.weekly :
 # chown root:root /etc/cron.weekly
 # chmod og-rwx /etc/cron.weekly
 
@@ -4441,8 +4233,8 @@ Run the following commands to set ownership and permissions on /etc/cron.weekly:
 5.1.6 Ensure permissions on /etc/cron.monthly are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/cron.monthly directory contains system cron jobs that need to run on a monthly
-basis. The files in this directory cannot be manipulated by the crontab command, but are
+The /etc/cron.monthly  directory contains system cron jobs that need to run on a monthly
+basis. The files in this directory cannot be manipulated by tcrontab command, but are
 instead edited by system administrators using a text editor. The commands below restrict
 read/write and search access to user and group root, preventing regular users from
 accessing this directory.
@@ -4452,18 +4244,12 @@ means for gaining unauthorized elevated privileges. Granting read access to this
 could give an unprivileged user insight in how to gain elevated privileges or circumvent
 auditing controls.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access does not
+Run the following command and verify Uid and Gid are both0/root and Access does not
 grant permissions to group or other:
 # stat /etc/cron.monthly
-Access: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------)  Uid: (  0/  root)  Gid: (  0/  root)
 Remediation:
-Run the following commands to set ownership and permissions on /etc/cron.monthly:
+Run the following commands to set ownership and permissions on  /etc/cron.monthly :
 # chown root:root /etc/cron.monthly
 # chmod og-rwx /etc/cron.monthly
 
@@ -4473,7 +4259,7 @@ Run the following commands to set ownership and permissions on /etc/cron.monthly
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 The /etc/cron.d directory contains system cron jobs that need to run in a similar manner
-to the hourly, daily weekly and monthly jobs from /etc/crontab, but require more
+to the hourly, daily weekly and monthly jobs from/etc/crontab , but require more
 granular control as to when they run. The files in this directory cannot be manipulated by
 the crontab command, but are instead edited by system administrators using a text editor.
 The commands below restrict read/write and search access to user and group root,
@@ -4484,18 +4270,12 @@ means for gaining unauthorized elevated privileges. Granting read access to this
 could give an unprivileged user insight in how to gain elevated privileges or circumvent
 auditing controls.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access does not
+Run the following command and verify Uid and Gid are both0/root and Access does not
 grant permissions to group or other:
 # stat /etc/cron.d
-Access: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------)  Uid: (  0/  root)  Gid: (  0/  root)
 Remediation:
-Run the following commands to set ownership and permissions on /etc/cron.d:
+Run the following commands to set ownership and permissions on  /etc/cron.d :
 # chown root:root /etc/cron.d
 # chmod og-rwx /etc/cron.d
 
@@ -4504,72 +4284,52 @@ Run the following commands to set ownership and permissions on /etc/cron.d:
 5.1.8 Ensure at/cron is restricted to authorized users (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-Configure /etc/cron.allow and /etc/at.allow to allow specific users to use these
-services. If /etc/cron.allow or /etc/at.allow do not exist, then /etc/at.deny and
-/etc/cron.deny are checked. Any user not specifically defined in those files is allowed to
-use at and cron. By removing the files, only users in /etc/cron.allow and /etc/at.allow
+Configure /etc/cron.allow  and /etc/at.allow  to allow specific users to use these
+services. I/etc/cron.allow  or/etc/at.allow  do not exist, the/etc/at.deny  and
+/etc/cron.deny  are checked. Any user not specifically defined in those files is allowed to
+use at and cron. By removing the files, only users/etc/cron.allow  and /etc/at.allow
 are allowed to use at and cron. Note that even though a given user is not listed in
-cron.allow, cron jobs can still be run as that user. The cron.allow file only controls
+cron.allow , cron jobs can still be run as that user.cron.allow file only controls
 administrative access to the crontab command for scheduling and modifying cron jobs.
 Rationale:
-On many systems, only the system administrator is authorized to schedule cron jobs. Using
-the cron.allow file to control who can run cron jobs enforces this policy. It is easier to
+On many systems, only the system administrator is authorized to schedulecron jobs. Using
+the cron.allow file to control who can rucron jobs enforces this policy. It is easier to
 manage an allow list than a deny list. In a deny list, you could potentially add a user ID to
 the system and forget to add it to the deny files.
 Audit:
-Run the following commands and ensure /etc/cron.deny and /etc/at.deny do not exist:
+Run the following commands and ensure  /etc/cron.deny and /etc/at.deny do not exist:
 # stat /etc/cron.deny
 stat: cannot stat `/etc/cron.deny': No such file or directory
 # stat /etc/at.deny
 stat: cannot stat `/etc/at.deny': No such file or directory
-Run the following command and verify Uid and Gid are both 0/root and Access does not
-grant permissions to group or other for both /etc/cron.allow and /etc/at.allow:
+Run the following command and verify Uid and Gid are both0/root and Access does not
+grant permissions togroup orother for both /etc/cron.allow and /etc/at.allow :
 # stat /etc/cron.allow
-Access: (0600/-rw-------)
+Access: (0600/-rw-------) Uid: (   0/  root)  Gid: (  0/  root)
 # stat /etc/at.allow
-Access: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------) Uid: (   0/  root)  Gid: (  0/  root)
 Remediation:
-Run the following commands to remove /etc/cron.deny and /etc/at.deny and create and
-set permissions and ownership for /etc/cron.allow and /etc/at.allow:
+Run the following commands to remove  /etc/cron.deny and /etc/at.deny and create and
+set permissions and ownership for /etc/cron.allow and /etc/at.allow :
 
-#
-#
-#
-#
-#
-#
-#
-#
-rm /etc/cron.deny
-rm /etc/at.deny
-touch /etc/cron.allow
-touch /etc/at.allow
-chmod og-rwx /etc/cron.allow
-chmod og-rwx /etc/at.allow
-chown root:root /etc/cron.allow
-chown root:root /etc/at.allow
+# rm /etc/cron.deny
+# rm /etc/at.deny
+# touch /etc/cron.allow
+# touch /etc/at.allow
+# chmod og-rwx /etc/cron.allow
+# chmod og-rwx /etc/at.allow
+# chown root:root /etc/cron.allow
+# chown root:root /etc/at.allow
 
 5.2 SSH Server Configuration
-SSH is a secure, encrypted replacement for common login services such as telnet, ftp,
-rlogin, rsh, and rcp. It is strongly recommended that sites abandon older clear-text login
+SSH is a secure, encrypted replacement for common login services such as telnet ,ftp ,
+rlogin ,rsh, and rcp. It is strongly recommended that sites abandon older clear-text login
 protocols and use SSH to prevent session hijacking and sniffing of sensitive data off the
 network.
 Note: The recommendations in this section only apply if the SSH daemon is installed on the
 system, if remote access is not required the SSH daemon can be removed and this section
 skipped.
-Note: Once all configuration changes have been made to /etc/ssh/sshd_config, the sshd
+Note: Once all configuration changes have been made to /etc/ssh/sshd_config  , the sshd
 configuration must be reloaded:
 # service sshd reload
 
@@ -4577,23 +4337,19 @@ configuration must be reloaded:
 (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/ssh/sshd_config file contains configuration specifications for sshd. The
+The /etc/ssh/sshd_config   file contains configuration specifications sshd . The
 command below sets the owner and group of the file to root.
 Rationale:
-The /etc/ssh/sshd_config file needs to be protected from unauthorized changes by nonprivileged users.
+The /etc/ssh/sshd_config   file needs to be protected from unauthorized changes by non-
+privileged users.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access does not
-grant permissions to group or other:
+Run the following command and verify  Uid and Gid are both 0/root and Access does not
+grant permissions to group or other :
 
 # stat /etc/ssh/sshd_config
-Access: (0600/-rw-------) Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------)  Uid: (   0/  root)  Gid: (   0/   root)
 Remediation:
-Run the following commands to set ownership and permissions on /etc/ssh/sshd_config:
+Run the following commands to set ownership and permissions on   /etc/ssh/sshd_config  :
 # chown root:root /etc/ssh/sshd_config
 # chmod og-rwx /etc/ssh/sshd_config
 
@@ -4611,7 +4367,7 @@ Run the following command and verify that output matches:
 # grep "^Protocol" /etc/ssh/sshd_config
 Protocol 2
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config   file to set the parameter as follows:
 Protocol 2
 
 
@@ -4623,7 +4379,7 @@ The INFO parameter specifies that login and logout activity will be logged.
 Rationale:
 SSH provides several logging levels with varying amounts of verbosity. DEBUG is specifically
 not recommended other than strictly for debugging SSH communications since it provides
-so much data that it is difficult to identify important security information. INFO level is the
+so much data that it is difficult to identify important security informatINFO level is the
 basic level that only records login activity of SSH users. In many situations, such as Incident
 Response, it is important to determine when a particular user was active on a system. The
 logout record can eliminate those users who disconnected, which helps narrow the field.
@@ -4632,7 +4388,7 @@ Run the following command and verify that output matches:
 # grep "^LogLevel" /etc/ssh/sshd_config
 LogLevel INFO
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config   file to set the parameter as follows:
 LogLevel INFO
 
 
@@ -4652,7 +4408,7 @@ Run the following command and verify that output matches:
 # grep "^X11Forwarding" /etc/ssh/sshd_config
 X11Forwarding no
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config   file to set the parameter as follows:
 X11Forwarding no
 
 
@@ -4660,19 +4416,19 @@ X11Forwarding no
 5.2.5 Ensure SSH MaxAuthTries is set to 4 or less (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The MaxAuthTries parameter specifies the maximum number of authentication attempts
+The MaxAuthTries  parameter specifies the maximum number of authentication attempts
 permitted per connection. When the login failure count reaches half the number, error
-messages will be written to the syslog file detailing the login failure.
+messages will be written to thesyslog file detailing the login failure.
 Rationale:
-Setting the MaxAuthTries parameter to a low number will minimize the risk of successful
+Setting theMaxAuthTries  parameter to a low number will minimize the risk of successful
 brute force attacks to the SSH server. While the recommended setting is 4, set the number
 based on site policy.
 Audit:
-Run the following command and verify that output MaxAuthTries is 4 or less:
+Run the following command and verify that output MaxAuthTries  is 4 or less:
 # grep "^MaxAuthTries" /etc/ssh/sshd_config
 MaxAuthTries 4
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config   file to set the parameter as follows:
 MaxAuthTries 4
 
 
@@ -4680,16 +4436,15 @@ MaxAuthTries 4
 5.2.6 Ensure SSH IgnoreRhosts is enabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The IgnoreRhosts parameter specifies that .rhosts and .shosts files will not be used in
-RhostsRSAAuthentication or HostbasedAuthentication.
+The IgnoreRhosts  parameter specifies that.rhosts  and .shosts files will not be used in
+RhostsRSAAuthentication   orHostbasedAuthentication  .
 Rationale:
 Setting this parameter forces users to enter a password when authenticating with ssh.
 Audit:
 Run the following command and verify that output matches:
-# grep "^IgnoreRhosts" /etc/ssh/sshd_config
-IgnoreRhosts yes
+IgnoreRhosts yeshosts" /etc/ssh/sshd_config
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config  file to set the parameter as follows:
 IgnoreRhosts yes
 
 
@@ -4697,18 +4452,18 @@ IgnoreRhosts yes
 5.2.7 Ensure SSH HostbasedAuthentication is disabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The HostbasedAuthentication parameter specifies if authentication is allowed through
-trusted hosts via the user of .rhosts, or /etc/hosts.equiv, along with successful public
+The HostbasedAuthentication   parameter specifies if authentication is allowed through
+trusted hosts via the user o.rhosts , o/etc/hosts.equiv  , along with successful public
 key client host authentication. This option only applies to SSH Protocol Version 2.
 Rationale:
-Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf,
-disabling the ability to use .rhosts files in SSH provides an additional layer of protection .
+Even though the .rhosts files are ineffective if support is disabled/etc/pam.conf ,
+disabling the ability to us.rhosts files in SSH provides an additional layer of protection .
 Audit:
 Run the following command and verify that output matches:
 # grep "^HostbasedAuthentication" /etc/ssh/sshd_config
 HostbasedAuthentication no
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config   file to set the parameter as follows:
 HostbasedAuthentication no
 
 
@@ -4716,18 +4471,18 @@ HostbasedAuthentication no
 5.2.8 Ensure SSH root login is disabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The PermitRootLogin parameter specifies if the root user can log in using ssh(1). The
+The PermitRootLogin  parameter specifies if the root user can log in using ssh(1). The
 default is no.
 Rationale:
 Disallowing root logins over SSH requires system admins to authenticate using their own
-individual account, then escalating to root via sudo or su. This in turn limits opportunity
+individual account, then escalating to root vsudo or su. This in turn limits opportunity
 for non-repudiation and provides a clear audit trail in the event of a security incident
 Audit:
 Run the following command and verify that output matches:
 # grep "^PermitRootLogin" /etc/ssh/sshd_config
 PermitRootLogin no
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config   file to set the parameter as follows:
 PermitRootLogin no
 
 
@@ -4735,7 +4490,7 @@ PermitRootLogin no
 5.2.9 Ensure SSH PermitEmptyPasswords is disabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The PermitEmptyPasswords parameter specifies if the SSH server allows login to accounts
+The PermitEmptyPasswords  parameter specifies if the SSH server allows login to accounts
 with empty password strings.
 Rationale:
 Disallowing remote shell access to accounts that have an empty password reduces the
@@ -4745,7 +4500,7 @@ Run the following command and verify that output matches:
 # grep "^PermitEmptyPasswords" /etc/ssh/sshd_config
 PermitEmptyPasswords no
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config  file to set the parameter as follows:
 PermitEmptyPasswords no
 
 
@@ -4753,7 +4508,7 @@ PermitEmptyPasswords no
 5.2.10 Ensure SSH PermitUserEnvironment is disabled (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The PermitUserEnvironment option allows users to present environment options to the
+The PermitUserEnvironment  option allows users to present environment options to the
 ssh daemon.
 Rationale:
 Permitting users the ability to set environment variables through the SSH daemon could
@@ -4764,7 +4519,7 @@ Run the following command and verify that output matches:
 # grep PermitUserEnvironment /etc/ssh/sshd_config
 PermitUserEnvironment no
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config  file to set the parameter as follows:
 PermitUserEnvironment no
 
 
@@ -4783,10 +4538,13 @@ Audit:
 Run the following command and verify that output does not contain any unlisted MAC
 algorithms:
 # grep "MACs" /etc/ssh/sshd_config
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519sha256@libssh.org,diffie-hellman-group-exchange-sha256
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-
+etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com,curve25519-
+sha256@libssh.org,diffie-hellman-group-exchange-sha256
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
-MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
+Edit the/etc/ssh/sshd_config  file to set the parameter as follows:
+MACs hmac-sha2-512-etm@openssh.com,hmac-sha2-256-etm@openssh.com,umac-128-
+etm@openssh.com,hmac-sha2-512,hmac-sha2-256,umac-128@openssh.com
 References:
 1. More information on SSH downgrade attacks can be found here:
 http://www.mitls.org/pages/attacks/SLOTH
@@ -4800,31 +4558,30 @@ MACs used are in compliance with site policy.
 5.2.12 Ensure SSH Idle Timeout Interval is configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The two options ClientAliveInterval and ClientAliveCountMax control the timeout of
-ssh sessions. When the ClientAliveInterval variable is set, ssh sessions that have no
-activity for the specified length of time are terminated. When the ClientAliveCountMax
-variable is set, sshd will send client alive messages at every ClientAliveInterval
+The two options ClientAliveInterval  and ClientAliveCountMax   control the timeout of
+ssh sessions. When the ClientAliveInterval   variable is set, ssh sessions that have no
+activity for the specified length of time are terminated. When thClientAliveCountMax
+variable is setsshd will send client alive messages at everClientAliveInterval
 interval. When the number of consecutive client alive messages are sent with no response
-from the client, the ssh session is terminated. For example, if the ClientAliveInterval is
-set to 15 seconds and the ClientAliveCountMax is set to 3, the client ssh session will be
+from the client, thssh session is terminated. For example, if thClientAliveInterval  is
+set to 15 seconds and the ClientAliveCountMax  is set to 3, the clissh session will be
 terminated after 45 seconds of idle time.
 Rationale:
 Having no timeout value associated with a connection could allow an unauthorized user
-access to another user's ssh session (e.g. user walks away from their computer and doesn't
+access to another user'sssh session (e.g. user walks away from their computer and doesn't
 lock the screen). Setting a timeout value at least reduces the risk of this happening..
 While the recommended setting is 300 seconds (5 minutes), set this timeout value based on
-site policy. The recommended setting for ClientAliveCountMax is 0. In this case, the client
+site policy. The recommended setting for ClientAliveCountMax  is 0. In this case, the client
 session will be terminated after 5 minutes of idle time and no keepalive messages will be
 sent.
 Audit:
-Run the following commands and verify ClientAliveInterval is 300 or less and
-ClientAliveCountMax is 3 or less:
+Run the following commands and verify  ClientAliveInterval  is 300 or less and
+ClientAliveCountMax  is 3 or less:
 # grep "^ClientAliveInterval" /etc/ssh/sshd_config
-ClientAliveInterval 300
 # grep "^ClientAliveCountMax" /etc/ssh/sshd_config
 ClientAliveCountMax 0
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameters as follows:
+Edit the/etc/ssh/sshd_config   file to set the parameters as follows:
 
 ClientAliveInterval 300
 ClientAliveCountMax 0
@@ -4834,21 +4591,21 @@ ClientAliveCountMax 0
 5.2.13 Ensure SSH LoginGraceTime is set to one minute or less (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The LoginGraceTime parameter specifies the time allowed for successful authentication to
+The LoginGraceTime  parameter specifies the time allowed for successful authentication to
 the SSH server. The longer the Grace period is the more open unauthenticated connections
 can exist. Like other session controls in this session the Grace Period should be limited to
 appropriate organizational limits to ensure the service is available for needed access.
 Rationale:
-Setting the LoginGraceTime parameter to a low number will minimize the risk of
+Setting theLoginGraceTime  parameter to a low number will minimize the risk of
 successful brute force attacks to the SSH server. It will also limit the number of concurrent
 unauthenticated connections While the recommended setting is 60 seconds (1 Minute), set
 the number based on site policy.
 Audit:
-Run the following command and verify that output LoginGraceTime is 60 or less:
+Run the following command and verify that output LoginGraceTime  is 60 or less:
 # grep "^LoginGraceTime" /etc/ssh/sshd_config
 LoginGraceTime 60
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config   file to set the parameter as follows:
 LoginGraceTime 60
 
 
@@ -4859,24 +4616,24 @@ Description:
 There are several options available to limit which users and group can access the system
 via SSH. It is recommended that at least one of the following options be leveraged:
 AllowUsers
-The AllowUsers variable gives the system administrator the option of allowing specific
-users to ssh into the system. The list consists of comma separated user names. Numeric
+The AllowUsers  variable gives the system administrator the option of allowing specific
+users tossh into the system. The list consists of comma separated user names. Numeric
 user IDs are not recognized with this variable. If a system administrator wants to restrict
 user access further by only allowing the allowed users to log in from a particular host, the
 entry can be specified in the form of user@host.
 AllowGroups
-The AllowGroups variable gives the system administrator the option of allowing specific
-groups of users to ssh into the system. The list consists of comma separated group names.
+The AllowGroups  variable gives the system administrator the option of allowing specific
+groups of users tossh into the system. The list consists of comma separated group names.
 Numeric group IDs are not recognized with this variable.
 DenyUsers
-The DenyUsers variable gives the system administrator the option of denying specific
-users to ssh into the system. The list consists of comma separated user names. Numeric
+The DenyUsers  variable gives the system administrator the option of denying specific
+users tossh into the system. The list consists of comma separated user names. Numeric
 user IDs are not recognized with this variable. If a system administrator wants to restrict
 user access further by specifically denying a user's access from a particular host, the entry
 can be specified in the form of user@host.
 DenyGroups
-The DenyGroups variable gives the system administrator the option of denying specific
-groups of users to ssh into the system. The list consists of comma separated group names.
+The DenyGroups  variable gives the system administrator the option of denying specific
+groups of users tossh into the system. The list consists of comma separated group names.
 Numeric group IDs are not recognized with this variable.
 Rationale:
 Restricting which users can remotely access the system via SSH will help ensure that only
@@ -4893,7 +4650,7 @@ DenyUsers <userlist>
 # grep "^DenyGroups" /etc/ssh/sshd_config
 DenyGroups <grouplist>
 Remediation:
-Edit the /etc/ssh/sshd_config file to set one or more of the parameter as follows:
+Edit the/etc/ssh/sshd_config   file to set one or more of the parameter as follows:
 AllowUsers <userlist>
 AllowGroups <grouplist>
 DenyUsers <userlist>
@@ -4915,30 +4672,26 @@ Run the following command and verify that output matches:
 # grep "^Banner" /etc/ssh/sshd_config
 Banner /etc/issue.net
 Remediation:
-Edit the /etc/ssh/sshd_config file to set the parameter as follows:
+Edit the/etc/ssh/sshd_config  file to set the parameter as follows:
 Banner /etc/issue.net
 
 5.3 Configure PAM
 PAM (Pluggable Authentication Modules) is a service that implements modular
 authentication modules on UNIX systems. PAM is implemented as a set of shared objects
 that are loaded and executed when a program needs to authenticate a user. Files for PAM
-are typically located in the /etc/pam.d directory. PAM must be carefully configured to
+are typically located in th/etc/pam.d directory. PAM must be carefully configured to
 secure system authentication. While this section covers some of PAM, please consult other
 PAM resources to fully understand the configuration capabilities.
 
 5.3.1 Ensure password creation requirements are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The pam_pwquality.so module checks the strength of passwords. It performs checks such
+The pam_pwquality.so  module checks the strength of passwords. It performs checks such
 as making sure a password is not a dictionary word, it is a certain length, contains a mix of
 characters (e.g. alphabet, numeric, other) and more. The following are definitions of
-the pam_pwquality.so options. try_first_pass - retrieve the password from a previous stacked PAM module. If not available, then prompt the user for a password.
-retry=3 - Allow 3 tries before sending back a failure.
-The following options are set in the /etc/security/pwquality.conf file: minlen=14 - password must be 14 characters or more
-dcredit=-1 - provide at least one digit
-ucredit=-1 - provide at least one uppercase character
-ocredit=-1 - provide at least one special character
-lcredit=-1 - provide at least one lowercase character
+the pam_pwquality.so  options.  try_first_pass  - retrieve the password from a previous stacked PAM module. If
+not available, then prompt the user for a password.  retry=3 - Allow 3 tries before sending back a failure.
+The following options are set in the/etc/security/pwquality.conf   file:  minlen=14  - password must be 14 characters or more  dcredit=-1  - provide at least one digit  ucredit=-1  - provide at least one uppercase character  ocredit=-1  - provide at least one special character  lcredit=-1  - provide at least one lowercase character
 The settings shown above are one possible policy. Alter these values to conform to your
 own organization's password policies.
 Rationale:
@@ -4961,10 +4714,10 @@ ucredit=-1
 Remediation:
 Run the following command to install the pam_pwquality module:
 apt-get install libpam-pwquality
-Edit the /etc/pam.d/common-passwd file to include the appropriate options
-for pam_pwquality.so and to conform to site policy:
+Edit the/etc/pam.d/common-passwd   file to include the appropriate options
+forpam_pwquality.so  and to conform to site policy:
 password requisite pam_pwquality.so try_first_pass retry=3
-Edit /etc/security/pwquality.conf to add or update the following settings to conform to
+Edit /etc/security/pwquality.conf   to add or update the following settings to conform to
 site policy:
 minlen=14
 dcredit=-1
@@ -4994,11 +4747,11 @@ Perform the following to determine the current settings for user lockout.
 # grep "pam_tally2" /etc/pam.d/common-auth
 auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900
 Remediation:
-Edit the /etc/pam.d/common-auth file and add the auth line below:
+Edit the/etc/pam.d/common-auth   file and add the auth line below:
 auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900
 Note: If a user has been locked out because they have reached the maximum consecutive
-failure count defined by deny= in the pam_tally2.so module, the user can be unlocked by
-issuing the command /sbin/pam_tally2 -u <username> --reset. This command sets the
+failure count defined bydeny= in thepam_tally2.so  module, the user can be unlocked by
+issuing the command /sbin/pam_tally2 -u  <username>  --reset . This command sets the
 failed count to 0, effectively unlocking the user.
 
 
@@ -5006,19 +4759,19 @@ failed count to 0, effectively unlocking the user.
 5.3.3 Ensure password reuse is limited (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/security/opasswd file stores the users' old passwords and can be checked to
+The /etc/security/opasswd   file stores the users' old passwords and can be checked to
 ensure that users are not recycling recent passwords.
 Rationale:
 Forcing users not to reuse their past 5 passwords make it less likely that an attacker will be
 able to guess the password.
 Note that these change only apply to accounts configured on the local system.
 Audit:
-Run the following commands and ensure the remember option is '5' or more and included in
+Run the following commands and ensure the  remember option is 5' or more and included in
 all results:
 # egrep '^password\s+sufficient\s+pam_unix.so' /etc/pam.d/common-password
 password sufficient pam_unix.so remember=5
 Remediation:
-Edit the /etc/pam.d/common-password file to include the remember option and conform to
+Edit the/etc/pam.d/common-password   file to include tremember option and conform to
 site policy as shown:
 password sufficient pam_unix.so remember=5
 Notes:
@@ -5029,7 +4782,7 @@ Additional module options may be set, recommendation only covers those listed he
 5.3.4 Ensure password hashing algorithm is SHA-512 (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The commands below change password encryption from md5 to sha512 (a much stronger
+The commands below change password encryption from   md5 tosha512 (a much stronger
 hashing algorithm). All existing accounts will need to perform a password change to
 upgrade the stored hashes to the new algorithm.
 Rationale:
@@ -5042,7 +4795,7 @@ Run the following commands and ensure the sha512 option is included in all resul
 # egrep '^password\s+\S+\s+pam_unix.so' /etc/pam.d/common-password
 password sufficient pam_unix.so sha512
 Remediation:
-Edit the /etc/pam.d/common-password file to include the sha512 option for pam_unix.so as
+Edit the/etc/pam.d/common-password   file to include tsha512 option for pam_unix.so as
 shown:
 password [success=1 default=ignore] pam_unix.so sha512
 Notes:
@@ -5062,39 +4815,37 @@ and their environment.
 5.4.1 Set Shadow Password Suite Parameters
 While a majority of the password control parameters have been moved to PAM, some
 parameters are still available through the shadow password suite. Any changes made to
-/etc/login.defs will only be applied if the usermod command is used. If user IDs are
-added a different way, use the chage command to effect changes to individual user IDs.
+/etc/login.defs  will only be applied if thusermod command is used. If user IDs are
+added a different way, use thechage command to effect changes to individual user IDs.
 
 5.4.1.1 Ensure password expiration is 90 days or less (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The PASS_MAX_DAYS parameter in /etc/login.defs allows an administrator to force
+The PASS_MAX_DAYS  parameter in /etc/login.defs  allows an administrator to force
 passwords to expire once they reach a defined age. It is recommended that the
-PASS_MAX_DAYS parameter be set to less than or equal to 90 days.
+PASS_MAX_DAYS  parameter be set to less than or equal to 90 days.
 Rationale:
 The window of opportunity for an attacker to leverage compromised credentials or
 successfully compromise credentials via an online brute force attack is limited by the age of
 the password. Therefore, reducing the maximum age of a password also reduces an
 attacker's window of opportunity.
 Audit:
-Run the following command and verify PASS_MAX_DAYS is 90 or less:
+Run the following command and verify PASS_MAX_DAYS  is 90 or less:
 # grep PASS_MAX_DAYS /etc/login.defs
 PASS_MAX_DAYS 90
 Verify all users with a password have their maximum days between password change set
 to 90 or less:
-# egrep ^[^:]+:[^\!*] /etc/shadow | cut -d: -f1
-<list of users>
+<list of users>[^\!*] /etc/shadow | cut -d: -f1
 # chage --list <user>
-Maximum number of days between password change
-: 90
+Maximum number of days between password change      : 90
 Remediation:
-Set the PASS_MAX_DAYS parameter to 90 in /etc/login.defs:
+Set thePASS_MAX_DAYS  parameter to 90 in/etc/login.defs :
 
 PASS_MAX_DAYS 90
 Modify user parameters for all users with a password set to match:
 # chage --maxdays 90 <user>
 Notes:
-You can also check this setting in /etc/shadow directly. The 5th field should be 90 or less
+You can also check this setting in/etc/shadow  directly. The 5th field should be 90 or less
 for all users with a password.
 
 
@@ -5103,9 +4854,9 @@ for all users with a password.
 (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The PASS_MIN_DAYS parameter in /etc/login.defs allows an administrator to prevent
+The PASS_MIN_DAYS  parameter in /etc/login.defs  allows an administrator to prevent
 users from changing their password until a minimum number of days have passed since the
-last time the user changed their password. It is recommended that PASS_MIN_DAYS
+last time the user changed their password. It is recommended thatPASS_MIN_DAYS
 parameter be set to 7 or more days.
 Rationale:
 By restricting the frequency of password changes, an administrator can prevent users from
@@ -5117,12 +4868,10 @@ PASS_MIN_DAYS 7
 Verify all users with a password have their minimum days between password change set to
 7 or more:
 # egrep ^[^:]+:[^\!*] /etc/shadow | cut -d: -f1
-<list of users>
 # chage --list <user>
-Minimum number of days between password change
-: 7
+Minimum number of days between password change      : 7
 Remediation:
-Set the PASS_MIN_DAYS parameter to 7 in /etc/login.defs:
+Set thePASS_MIN_DAYS parameter to 7 in /etc/login.defs :
 PASS_MIN_DAYS 7
 Modify user parameters for all users with a password set to match:
 # chage --mindays 7 <user>
@@ -5136,31 +4885,28 @@ for all users with a password.
 5.4.1.3 Ensure password expiration warning days is 7 or more (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The PASS_WARN_AGE parameter in /etc/login.defs allows an administrator to notify users
+The PASS_WARN_AGE  parameter in /etc/login.defs  allows an administrator to notify users
 that their password will expire in a defined number of days. It is recommended that the
-PASS_WARN_AGE parameter be set to 7 or more days.
+PASS_WARN_AGE  parameter be set to 7 or more days.
 Rationale:
 Providing an advance warning that a password will be expiring gives users time to think of
 a secure password. Users caught unaware may choose a simple password or write it down
 where it may be discovered.
 Audit:
-Run the following command and verify PASS_WARN_AGE is 7 or more:
-# grep PASS_WARN_AGE /etc/login.defs
-PASS_WARN_AGE 7
+Run the following command and verify  PASS_WARN_AGE is 7 or more:
+PASS_WARN_AGE 7N_AGE /etc/login.defs
 Verify all users with a password have their number of days of warning before password
 expires set to 7 or more:
-# egrep ^[^:]+:[^\!*] /etc/shadow | cut -d: -f1
-<list of users>
+<list of users>[^\!*] /etc/shadow | cut -d: -f1
 # chage --list <user>
-Number of days of warning before password expires
-: 7
+Number of days of warning before password expires     : 7
 Remediation:
-Set the PASS_WARN_AGE parameter to 7 in /etc/login.defs:
+Set thePASS_WARN_AGE  parameter to 7 in /etc/login.defs :
 PASS_WARN_AGE 7
 Modify user parameters for all users with a password set to match:
 # chage --warndays 7 <user>
 Notes:
-You can also check this setting in /etc/shadow directly. The 6th field should be 7 or more
+You can also check this setting i/etc/shadow directly. The 6th field should be 7 or more
 for all users with a password.
 
 
@@ -5175,23 +4921,21 @@ Rationale:
 Inactive accounts pose a threat to system security since the users are not logging in to
 notice failed login attempts or other anomalies.
 Audit:
-Run the following command and verify INACTIVE is 30 or less:
-# useradd -D | grep INACTIVE
-INACTIVE=35
+Run the following command and verify  INACTIVE is 30 or less:
+INACTIVE=35D | grep INACTIVE
 Verify all users with a password have Password inactive no more than 30 days after
 password expires:
 # egrep ^[^:]+:[^\!*] /etc/shadow | cut -d: -f1
 <list of users>
 # chage --list <user>
-Password inactive
-: <date>
+Password inactive                     : <date>
 Remediation:
 Run the following command to set the default password inactivity period to 30 days:
 # useradd -D -f 30
 Modify user parameters for all users with a password set to match:
 # chage --inactive 30 <user>
 Notes:
-You can also check this setting in /etc/shadow directly. The 7th field should be 30 or less
+You can also check this setting i/etc/shadow  directly. The 7th field should be 30 or less
 for all users with a password.
 
 
@@ -5205,21 +4949,19 @@ Rationale:
 It is important to make sure that accounts that are not being used by regular users are
 prevented from being used to provide an interactive shell. By default, Ubuntu sets the
 password field for these accounts to an invalid string, but it is also recommended that the
-shell field in the password file be set to /sbin/nologin. This prevents the account from
+shell field in the password file be set /sbin/nologin . This prevents the account from
 potentially being used to run any commands.
 Audit:
 Run the following script and verify no results are returned:
-egrep -v "^\+" /etc/passwd | awk -F: '($1!="root" && $1!="sync" && $1!="shutdown" &&
-$1!="halt" && $3<1000 && $7!="/usr/sbin/nologin" && $7!="/bin/false") {print}'
+$1!="halt" && $3<1000 && $7!="/usr/sbin/nologin" && $7!="/bin/false") {print}'wn" &&
 Remediation:
-Set the shell for any accounts returned by the audit script to /usr/sbin/nologin:
+Set the shell for any accounts returned by the audit script t/usr/sbin/nologin  :
 # usermod -s /usr/sbin/nologin <user>
-The following script will automatically set all user shells required to /usr/sbin/nologin
-and lock the sync, shutdown, and halt users:
+The following script will automatically set all user shells required /usr/sbin/nologin
+and lock the sync ,shutdown , andhalt users:
 #!/bin/bash
 for user in `awk -F: '($3 < 1000) {print $1 }' /etc/passwd`; do
 if [ $user != "root" ]; then
-usermod -L $user
 if [ $user != "sync" ] && [ $user != "shutdown" ] && [ $user != "halt" ]; then
 usermod -s /usr/sbin/nologin $user
 fi
@@ -5241,7 +4983,7 @@ Run the following command and verify the result is 0:
 # grep "^root:" /etc/passwd | cut -f4 -d:
 0
 Remediation:
-Run the following command to set the root user default group to GID 0:
+Run the following command to set the  root user default group to GID 0:
 # usermod -g 0 root
 
 
@@ -5252,24 +4994,23 @@ Description:
 The default umask determines the permissions of files created by users. The user creating
 the file has the discretion of making their files and directories readable by others via the
 chmod command. Users who wish to allow their files and directories to be readable by
-others by default may choose a different default umask by inserting the umask command
-into the standard shell configuration files (.profile, .bashrc, etc.) in their home
+others by default may choose a different default umask by inserting theumask command
+into the standard shell configuration file.profile ,.bashrc , etc.) in their home
 directories.
 Rationale:
-Setting a very secure default value for umask ensures that users make a conscious choice
-about their file permissions. A default umask setting of 077 causes files and directories
-created by users to not be readable by any other user on the system. A umask of 027 would
-make files and directories readable by users in the same Unix group, while a umask of 022
+Setting a very secure default value foumask ensures that users make a conscious choice
+about their file permissions. A defaulumask setting of077 causes files and directories
+created by users to not be readable by any other user on the system. Aumask of027 would
+make files and directories readable by users in the same Unix group, while umask of 022
 would make files readable by every user on the system.
 Audit:
 Run the following commands and verify all umask lines returned are 027 or more
 restrictive.
 # grep "^umask" /etc/bash.bashrc
 umask 027
-# grep "^umask" /etc/profile
-umask 027
+umask 027umask" /etc/profile
 Remediation:
-Edit the /etc/bash.bashrc and /etc/profile files (and the appropriate files for any other
+Edit the/etc/bash.bashrc  and /etc/profile  files (and the appropriate files for any other
 shell supported on your system) and add or edit any umask parameters as follows:
 umask 027
 Notes:
@@ -5288,7 +5029,7 @@ override.
 5.5 Ensure root login is restricted to system console (Not Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The file /etc/securetty contains a list of valid terminals that may be logged in directly as
+The file/etc/securetty  contains a list of valid terminals that may be logged in directly as
 root.
 Rationale:
 Since the system console has special properties to handle emergency situations, it is
@@ -5305,15 +5046,15 @@ Remove entries for any consoles that are not in a physically secure location.
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 The su command allows a user to run a command or shell as another user. The program
-has been superseded by sudo, which allows for more granular control over privileged
-access. Normally, the su command can be executed by any user. By uncommenting the
-pam_wheel.so statement in /etc/pam.d/su, the su command will only allow users in the
-wheel group to execute su.
+has been superseded by sudo , which allows for more granular control over privileged
+access. Normally, thesu command can be executed by any user. By uncommenting the
+pam_wheel.so  statement in /etc/pam.d/su , thsu command will only allow users in the
+wheel group to execute su .
 Rationale:
-Restricting the use of su, and using sudo in its place, provides system administrators better
+Restricting the use osu, and usingsudo in its place, provides system administrators better
 control of the escalation of user privileges to execute privileged commands. The sudo utility
 also provides a better logging and audit mechanism, as it can log each command executed
-via sudo, whereas su can only record that a user executed the su program.
+viasudo , whereas su can only record that a user executed thesu program.
 Audit:
 Run the following command and verify output includes matching line:
 # grep pam_wheel.so /etc/pam.d/su
@@ -5322,43 +5063,42 @@ Run the following command and verify users in wheel group match site policy:
 # grep wheel /etc/group
 wheel:x:10:root,<user list>
 Remediation:
-Add the following line to the /etc/pam.d/su file:
+Add the following line to th/etc/pam.d/su  file:
 auth required pam_wheel.so use_uid
-Create a comma separated list of users in the wheel statement in the /etc/group file:
+Create a comma separated list of users in the wheel statement in th/etc/group  file:
 wheel:x:10:root,<user list>
+6 System Maintenance
+
+Recommendations in this section are intended as maintenance and are intended to be
+checked on a frequent basis to ensure system stability. Many recommendations do not
+have quick remediations and require investigation into the cause and best fix available and
+may indicate an attempted breach of system security.
+
 6.1 System File Permissions
 This section provides guidance on securing aspects of system files and directories.
 
 6.1.1 Audit system file permissions (Not Scored)
 Profile Applicability: Level 2 - Server Level 2 - Workstation
 Description:
-The Debian package manager has a number of useful options. One of these, the -verify option, can be used to verify that system packages are correctly installed. The -verify option can be used to verify a particular package or to verify all system packages. If
+The Debian package manager has a number of useful options. One of these, the --
+verify option, can be used to verify that system packages are correctly installed. --e
+verify option can be used to verify a particular package or to verify all system packages. If
 no output is returned, the package is installed correctly. The following table describes the
 meaning of output from the verify option:
-Code
-S
-M
-5
-D
-L
-U
-G
-T
-Meaning
-File size differs.
-File mode differs (includes permissions and file type).
-The MD5 checksum differs.
-The major and minor version numbers differ on a device file.
-A mismatch occurs in a link.
-The file ownership differs.
-The file group owner differs.
-The file time (mtime) differs.
+Code  Meaning
+S   File size differs.
+M   File mode differs (includes permissions and file type).
+5   The MD5 checksum differs.
+D   The major and minor version numbers differ on a device file.
+U   The file ownership differs..
+G   The file group owner differs.
+T   The file time (mtime) differs.
 The dpkg -S command can be used to determine which package a particular file belongs to.
-For example the following commands determines which package the /bin/bash file
+For example the following commands determines which package the   /bin/bash file
 belongs to:
 # dpkg -S /bin/bash
 bash: /bin/bash
-To verify the settings for the package that controls the /bin/bash file, run the following:
+To verify the settings for the package that controls /bin/bash  file, run the following:
 # dpkg --verify bash
 ??5 c /etc/bash.bashrc
 Rationale:
@@ -5367,14 +5107,15 @@ the permissions they were intended to have from the OS vendor.
 Audit:
 
 Run the following command to review all installed packages. Note that this may be very
-time consuming and may be best scheduled via the cron utility. It is recommended that the
+time consuming and may be best scheduled via the  cron utility. It is recommended that the
 output of this command be redirected to a file that can be reviewed later.
 # dpkg --verify > <filename>
 Remediation:
 Correct any discrepancies found and rerun the audit until output is clean or risk is
 mitigated or accepted.
 References:
-1. http://docs.fedoraproject.org/enUS/Fedora_Draft_Documentation/0.1/html/RPM_Guide/index.html
+1. http://docs.fedoraproject.org/en-
+US/Fedora_Draft_Documentation/0.1/html/RPM_Guide/index.html
 Notes:
 Since packages and important files may change with new updates and releases, it is
 recommended to verify everything, not just a finite list of files. This can be a time
@@ -5389,24 +5130,18 @@ the new state is more secure than the default.
 6.1.2 Ensure permissions on /etc/passwd are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/passwd file contains user account information that is used by many system
+The /etc/passwd  file contains user account information that is used by many system
 utilities and therefore must be readable for these utilities to operate.
 Rationale:
-It is critical to ensure that the /etc/passwd file is protected from unauthorized write
+It is critical to ensure that /etc/passwd file is protected from unauthorized write
 access. Although it is protected by default, the file permissions could be changed either
 inadvertently or through malicious actions.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 644:
+Run the following command and verify  Uid and Gid are both 0/root and Access is644 :
 # stat /etc/passwd
-Access: (0644/-rw-r--r--)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0644/-rw-r--r--)  Uid: (   0/  root)  Gid: (   0/  root)
 Remediation:
-Run the following command to set permissions on /etc/passwd:
+Run the following command to set permissions on  /etc/passwd :
 # chown root:root /etc/passwd
 # chmod 644 /etc/passwd
 
@@ -5415,27 +5150,21 @@ Run the following command to set permissions on /etc/passwd:
 6.1.3 Ensure permissions on /etc/shadow are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/shadow file is used to store the information about user accounts that is critical to
+The /etc/shadow  file is used to store the information about user accounts that is critical to
 the security of those accounts, such as the hashed password and other security
 information.
 Rationale:
-If attackers can gain read access to the /etc/shadow file, they can easily run a password
+If attackers can gain read access to th/etc/shadow  file, they can easily run a password
 cracking program against the hashed password to break it. Other security information that
-is stored in the /etc/shadow file (such as expiration) could also be useful to subvert the
+is stored in the/etc/shadow  file (such as expiration) could also be useful to subvert the
 user accounts.
 Audit:
-Run the following command and verify Uid is 0/root, Gid is <gid>/shadow, and Access is
+Run the following command and verify  Uid is0/root ,Gid is <gid>/shadow , andAccess is
 640 or more restrictive:
 # stat /etc/shadow
-Access: (0640/-rw-r-----)
-Uid: (
-0/
-root)
-Gid: (
-42/
-shadow)
+Access: (0640/-rw-r-----)  Uid: (   0/  root)  Gid: (  42/ shadow)
 Remediation:
-Run the one following commands to set permissions on /etc/shadow:
+Run the one following commands to set permissions on  /etc/shadow  :
 # chown root:shadow /etc/shadow
 # chmod o-rwx,g-wx /etc/shadow
 
@@ -5444,24 +5173,17 @@ Run the one following commands to set permissions on /etc/shadow:
 6.1.4 Ensure permissions on /etc/group are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/group file contains a list of all the valid groups defined in the system. The
+The /etc/group  file contains a list of all the valid groups defined in the system. The
 command below allows read/write access for root and read access for everyone else.
 Rationale:
-The /etc/group file needs to be protected from unauthorized changes by non-privileged
+The /etc/group  file needs to be protected from unauthorized changes by non-privileged
 users, but needs to be readable as this information is used with many non-privileged
 programs.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 644:
-# stat /etc/group
-Access: (0644/-rw-r--r--)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Run the following command and verify Uid and Gid are both 0/root and Access is644:
+Access: (0644/-rw-r--r--)  Uid: (  0/  root)  Gid: (  0/   root)
 Remediation:
-Run the following command to set permissions on /etc/group:
+Run the following command to set permissions on /etc/group :
 # chown root:root /etc/group
 # chmod 644 /etc/group
 
@@ -5470,26 +5192,19 @@ Run the following command to set permissions on /etc/group:
 6.1.5 Ensure permissions on /etc/gshadow are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/gshadow file is used to store the information about groups that is critical to the
+The /etc/gshadow  file is used to store the information about groups that is critical to the
 security of those accounts, such as the hashed password and other security information.
 Rationale:
-If attackers can gain read access to the /etc/gshadow file, they can easily run a password
+If attackers can gain read access to th/etc/gshadow  file, they can easily run a password
 cracking program against the hashed password to break it. Other security information that
-is stored in the /etc/gshadow file (such as group administrators) could also be useful to
+is stored in th/etc/gshadow  file (such as group administrators) could also be useful to
 subvert the group.
 Audit:
 Run the following command and
-verify verify Uid is 0/root, Gid is <gid>/shadow, and Access is 640 or more restrictive:
-# stat /etc/gshadow
-Access: (0640/-rw-r-----)
-Uid: (
-0/
-root)
-Gid: (
-42/
-shadow)
+verify verifyUid is0/root, Gid is<gid>/shadow,  and Access is640 or more restrictive:
+Access: (0640/-rw-r-----)  Uid: (   0/  root)  Gid: (  42/ shadow)
 Remediation:
-Run the following commands to set permissions on /etc/gshadow:
+Run the following commands to set permissions on  /etc/gshadow :
 # chown root:shadow /etc/gshadow
 # chmod o-rwx,g-rw /etc/gshadow
 
@@ -5498,100 +5213,82 @@ Run the following commands to set permissions on /etc/gshadow:
 6.1.6 Ensure permissions on /etc/passwd- are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/passwd- file contains backup user account information.
+The /etc/passwd-  file contains backup user account information.
 Rationale:
-It is critical to ensure that the /etc/passwd- file is protected from unauthorized access.
+It is critical to ensure that/etc/passwd-  file is protected from unauthorized access.
 Although it is protected by default, the file permissions could be changed either
 inadvertently or through malicious actions.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 600 or
+Run the following command and verify Uid and Gid are both0/root and Access is600 or
 more restrictive:
-# stat /etc/passwdAccess: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------)  Uid: (  0/  root)  Gid: (  0/  root)
 Remediation:
-Run the following command to set permissions on /etc/passwd-:
-# chown root:root /etc/passwd# chmod 600 /etc/passwd-
+Run the following command to set permissions on /etc/passwd- :
+# chown root:root /etc/passwd-
+# chmod 600 /etc/passwd-
 
 
 
 6.1.7 Ensure permissions on /etc/shadow- are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/shadow- file is used to store backup information about user accounts that is
+The /etc/shadow-  file is used to store backup information about user accounts that is
 critical to the security of those accounts, such as the hashed password and other security
 information.
 Rationale:
-It is critical to ensure that the /etc/shadow- file is protected from unauthorized access.
+It is critical to ensure that/etc/shadow-  file is protected from unauthorized access.
 Although it is protected by default, the file permissions could be changed either
 inadvertently or through malicious actions.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 600 or
+Run the following command and verify Uid and Gid are both0/root and Access is600 or
 more restrictive:
-# stat /etc/shadowAccess: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+# stat /etc/shadow-
+Access: (0600/-rw-------)  Uid: (  0/  root)  Gid: (  0/  root)
 Remediation:
-Run the following command to set permissions on /etc/shadow-:
-# chown root:root /etc/shadow# chmod 600 /etc/shadow-
+Run the following command to set permissions on /etc/shadow- :
+# chown root:root /etc/shadow-
+# chmod 600 /etc/shadow-
 
 
 
 6.1.8 Ensure permissions on /etc/group- are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/group- file contains a backup list of all the valid groups defined in the system.
+The /etc/group-  file contains a backup list of all the valid groups defined in the system.
 Rationale:
-It is critical to ensure that the /etc/group- file is protected from unauthorized access.
+It is critical to ensure that/etc/group-  file is protected from unauthorized access.
 Although it is protected by default, the file permissions could be changed either
 inadvertently or through malicious actions.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 600 or
+Run the following command and verify Uid and Gid are both0/root and Access is600 or
 more restrictive:
-# stat /etc/groupAccess: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+Access: (0600/-rw-------)  Uid: (  0/  root)  Gid: (  0/  root)
 Remediation:
-Run the following command to set permissions on /etc/group-:
-# chown root:root /etc/group# chmod 600 /etc/group-
+Run the following command to set permissions on /etc/group- :
+# chown root:root /etc/group-
+# chmod 600 /etc/group-
 
 
 
 6.1.9 Ensure permissions on /etc/gshadow- are configured (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The /etc/gshadow- file is used to store backup information about groups that is critical to
+The /etc/gshadow-  file is used to store backup information about groups that is critical to
 the security of those accounts, such as the hashed password and other security
 information.
 Rationale:
-It is critical to ensure that the /etc/gshadow- file is protected from unauthorized access.
+It is critical to ensure that/etc/gshadow-  file is protected from unauthorized access.
 Although it is protected by default, the file permissions could be changed either
 inadvertently or through malicious actions.
 Audit:
-Run the following command and verify Uid and Gid are both 0/root and Access is 600 or
+Run the following command and verify Uid and Gid are both0/root and Access is600 or
 more restrictive:
-# stat /etc/gshadowAccess: (0600/-rw-------)
-Uid: (
-0/
-root)
-Gid: (
-0/
-root)
+# stat /etc/gshadow-
+Access: (0600/-rw-------)  Uid: (  0/  root)  Gid: (  0/  root)
 Remediation:
-Run the following command to set permissions on /etc/gshadow-:
-# chown root:root /etc/gshadow# chmod 600 /etc/gshadow-
+Run the following command to set permissions on /etc/gshadow- :
+# chown root:root /etc/gshadow-
+# chmod 600 /etc/gshadow-
 
 
 
@@ -5599,7 +5296,7 @@ Run the following command to set permissions on /etc/gshadow-:
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 Unix-based systems support variable settings to control access to files. World writable files
-are the least secure. See the chmod(2) man page for more information.
+are the least secure. See thchmod(2) man page for more information.
 Rationale:
 Data in world-writable files can be modified and compromised by any user on the system.
 World writable files may also indicate an incorrectly written script or program that could
@@ -5609,12 +5306,12 @@ Run the following command and verify no files are returned:
 # df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f
 -perm -0002
 The command above only searches local filesystems, there may still be compromised items
-on network mounted partitions. Additionally the --local option to df is not universal to
+on network mounted partitions. Additionally the --local option to dfis not universal to
 all versions, it can be omitted to search all filesystems on a system including network
 mounted filesystems or the following command can be run manually for each partition:
 # find <partition> -xdev -type f -perm -0002
 Remediation:
-Removing write access for the "other" category (chmod o-w <filename>) is advisable, but
+Removing write access for the "other" category (chmod o-w  <filename>) is advisable, but
 always consult relevant vendor documentation to avoid breaking any application
 dependencies on a given file.
 
@@ -5632,7 +5329,7 @@ Audit:
 Run the following command and verify no files are returned:
 # df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser
 The command above only searches local filesystems, there may still be compromised items
-on network mounted partitions. Additionally the --local option to df is not universal to
+on network mounted partitions. Additionally the --local option to dfis not universal to
 all versions, it can be omitted to search all filesystems on a system including network
 mounted filesystems or the following command can be run manually for each partition:
 # find <partition> -xdev -nouser
@@ -5654,7 +5351,7 @@ Audit:
 Run the following command and verify no files are returned:
 # df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup
 The command above only searches local filesystems, there may still be compromised items
-on network mounted partitions. Additionally the --local option to df is not universal to
+on network mounted partitions. Additionally the --local option to dfis not universal to
 all versions, it can be omitted to search all filesystems on a system including network
 mounted filesystems or the following command can be run manually for each partition:
 # find <partition> -xdev -nogroup
@@ -5679,7 +5376,7 @@ Run the following command to list SUID files:
 # df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f
 -perm -4000
 The command above only searches local filesystems, there may still be compromised items
-on network mounted partitions. Additionally the --local option to df is not universal to
+on network mounted partitions. Additionally the --local option to dfis not universal to
 all versions, it can be omitted to search all filesystems on a system including network
 mounted filesystems or the following command can be run manually for each partition:
 # find <partition> -xdev -type f -perm -4000
@@ -5706,7 +5403,7 @@ Run the following command to list SGID files:
 # df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -type f
 -perm -2000
 The command above only searches local filesystems, there may still be compromised items
-on network mounted partitions. Additionally the --local option to df is not universal to
+on network mounted partitions. Additionally the  --local option todf is not universal to
 all versions, it can be omitted to search all filesystems on a system including network
 mounted filesystems or the following command can be run manually for each partition:
 # find <partition> -xdev -type f -perm -2000
@@ -5729,7 +5426,7 @@ Audit:
 Run the following command and verify that no output is returned:
 # cat /etc/shadow | awk -F: '($2 == "" ) { print $1 " does not have a password "}'
 Remediation:
-If any accounts in the /etc/shadow file do not have a password, run the following
+If any accounts in th/etc/shadow  file do not have a password, run the following
 command to lock the account until it can be determined why it does not have a password:
 # passwd -l <username>
 Also, check to see if the account is logged in and investigate what it is being used for to
@@ -5749,7 +5446,7 @@ Audit:
 Run the following command and verify that no output is returned:
 # grep '^+:' /etc/passwd
 Remediation:
-Remove any legacy '+' entries from /etc/passwd if they exist.
+Remove any legacy '+' entries from /etc/passwd  if they exist.
 
 
 
@@ -5765,7 +5462,7 @@ Audit:
 Run the following command and verify that no output is returned:
 # grep '^+:' /etc/shadow
 Remediation:
-Remove any legacy '+' entries from /etc/shadow if they exist.
+Remove any legacy '+' entries from /etc/shadow  if they exist.
 
 
 
@@ -5790,7 +5487,7 @@ Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 Any account with UID 0 has superuser privileges on the system.
 Rationale:
-This access must be limited to only the default root account and only from the system
+This access must be limited to only the defaulroot account and only from the system
 console. Administrative access must be through an unprivileged account using an approved
 mechanism as noted in Item 5.6 Ensure access to the su command is restricted.
 Audit:
@@ -5806,9 +5503,9 @@ Remove any users other than root with UID 0 or assign them a new UID if appropri
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 The root user can execute any command on the system and could be fooled into executing
-programs unintentionally if the PATH is not set correctly.
+programs unintentionally if thePATH is not set correctly.
 Rationale:
-Including the current working directory (.) or other writable directory in root's executable
+Including the current working directory (.) or other writable directory root 's executable
 path makes it likely that an attacker can gain superuser access by forcing an administrator
 operating as root to execute a Trojan horse program.
 Audit:
@@ -5817,10 +5514,9 @@ Run the following script and verify no results are returned:
 if [ "`echo $PATH | grep :: `" != "" ]; then
 echo "Empty Directory in PATH (::)"
 fi
-if [ "`echo $PATH | grep :$`"
+if [ "`echo $PATH | grep :$`"  != "" ]; then
 echo "Trailing : in PATH"
 fi
-!= "" ]; then
 p=`echo $PATH | sed -e 's/::/:/' -e 's/:$//' -e 's/:/ /g'`
 set -- $p
 while [ "$1" != "" ]; do
@@ -5845,8 +5541,7 @@ else
 echo $1 is not a directory
 
 fi
-shift
-done
+doneift
 Remediation:
 Correct or justify any items discovered in the Audit step.
 
@@ -5887,8 +5582,7 @@ modify other users' data or to gain another user's system privileges.
 Audit:
 Run the following script and verify no results are returned:
 #!/bin/bash
-for dir in `cat /etc/passwd | egrep -v '(root|halt|sync|shutdown)' | awk -F: '($7 !=
-"/usr/sbin/nologin") { print $6 }'`; do
+"/usr/sbin/nologin") { print $6 }'`; dov '(root|halt|sync|shutdown)' | awk -F: '($7 !=
 dirperm=`ls -ld $dir | cut -f1 -d" "`
 if [ `echo $dirperm | cut -c6 ` != "-" ]; then
 echo "Group Write permission set on directory $dir"
@@ -5925,7 +5619,6 @@ Run the following script and verify no results are returned:
 cat /etc/passwd | awk -F: '{ print $1 " " $3 " " $6 }' | while read user uid dir; do
 if [ $uid -ge 1000 -a -d "$dir" -a $user != "nfsnobody" ]; then
 owner=$(stat -L -c "%U" "$dir")
-if [ "$owner" != "$user" ]; then
 echo "The home directory ($dir) of user $user is owned by $owner."
 fi
 fi
@@ -5952,19 +5645,15 @@ for dir in `cat /etc/passwd | egrep -v '(root|sync|halt|shutdown)' | awk -F: '($
 for file in $dir/.[A-Za-z0-9]*; do
 if [ ! -h "$file" -a -f "$file" ]; then
 fileperm=`ls -ld $file | cut -f1 -d" "`
-if [ `echo $fileperm | cut -c6
-echo "Group Write permission
+if [ `echo $fileperm | cut -c6 ` != "-" ]; then
+echo "Group Write permission set on file $file"
 fi
-if [ `echo $fileperm | cut -c9
-echo "Other Write permission
+if [ `echo $fileperm | cut -c9 ` != "-" ]; then
+echo "Other Write permission set on file $file"
 fi
 fi
 done
 done
-` != "-" ]; then
-set on file $file"
-` != "-" ]; then
-set on file $file"
 Remediation:
 Making global modifications to users' files without alerting the user community can result
 in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring
@@ -5976,10 +5665,10 @@ taken in accordance with site policy.
 6.2.11 Ensure no users have .forward files (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-The .forward file specifies an email address to forward the user's mail to.
+The .forward  file specifies an email address to forward the user's mail to.
 Rationale:
-Use of the .forward file poses a security risk in that sensitive data may be inadvertently
-transferred outside the organization. The .forward file also poses a risk as it can be used
+Use of the.forward  file poses a security risk in that sensitive data may be inadvertently
+transferred outside the organization. The.forward  file also poses a risk as it can be used
 to execute commands that may perform unintended actions.
 Audit:
 Run the following script and verify no results are returned:
@@ -5993,7 +5682,7 @@ done
 Remediation:
 Making global modifications to users' files without alerting the user community can result
 in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring
-policy be established to report user .forward files and determine the action to be taken in
+policy be established to report use.forward  files and determine the action to be taken in
 accordance with site policy.
 
 
@@ -6018,7 +5707,7 @@ done
 Remediation:
 Making global modifications to users' files without alerting the user community can result
 in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring
-policy be established to report user .netrc files and determine the action to be taken in
+policy be established to report use.netrc files and determine the action to be taken in
 accordance with site policy.
 
 
@@ -6030,9 +5719,8 @@ Description:
 While the system administrator can establish secure permissions for users' .netrc files,
 the users can easily override these.
 Rationale:
-files may contain unencrypted passwords that may be used to attack other
+.netrc files may contain unencrypted passwords that may be used to attack other
 systems.
-.netrc
 Audit:
 Run the following script and verify no results are returned:
 #!/bin/bash
@@ -6051,7 +5739,7 @@ if [ `echo $fileperm | cut -c7 ` != "-" ]; then
 echo "Group Execute set on $file"
 fi
 if [ `echo $fileperm | cut -c8 ` != "-" ]; then
-echo "Other Read set on $file"
+echo "Other Read  set on $file"
 fi
 if [ `echo $fileperm | cut -c9 ` != "-" ]; then
 echo "Other Write set on $file"
@@ -6079,8 +5767,8 @@ Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 While no .rhosts files are shipped by default, users can easily create them.
 Rationale:
-This action is only meaningful if .rhosts support is permitted in the file /etc/pam.conf.
-Even though the .rhosts files are ineffective if support is disabled in /etc/pam.conf, they
+This action is only meaningful i.rhosts  support is permitted in the fil/etc/pam.conf .
+Even though the .rhosts files are ineffective if support is disabled/etc/pam.conf , they
 may have been brought over from other systems and could contain information useful to
 an attacker for those other systems.
 Audit:
@@ -6091,13 +5779,12 @@ for dir in `cat /etc/passwd | egrep -v '(root|halt|sync|shutdown)' | awk -F: '($
 for file in $dir/.rhosts; do
 if [ ! -h "$file" -a -f "$file" ]; then
 echo ".rhosts file in $dir"
-fi
 done
 done
 Remediation:
 Making global modifications to users' files without alerting the user community can result
 in unexpected outages and unhappy users. Therefore, it is recommended that a monitoring
-policy be established to report user .rhosts files and determine the action to be taken in
+policy be established to report user.rhosts files and determine the action to be taken in
 accordance with site policy.
 
 
@@ -6106,9 +5793,9 @@ accordance with site policy.
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
 Over time, system administration errors and changes can lead to groups being defined in
-/etc/passwd but not in /etc/group.
+/etc/passwd  but not in/etc/group .
 Rationale:
-Groups defined in the /etc/passwd file but not in the /etc/group file pose a threat to
+Groups defined in the /etc/passwd  file but not in th/etc/group  file pose a threat to
 system security since group permissions are not properly managed.
 Audit:
 Run the following script and verify no results are returned:
@@ -6128,8 +5815,8 @@ any discrepancies found.
 6.2.16 Ensure no duplicate UIDs exist (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-Although the useradd program will not let you create a duplicate User ID (UID), it is
-possible for an administrator to manually edit the /etc/passwd file and change the UID
+Although the useradd  program will not let you create a duplicate User ID (UID), it is
+possible for an administrator to manually edit the/etc/passwd  file and change the UID
 field.
 Rationale:
 Users must be assigned unique UIDs for accountability and to ensure appropriate access
@@ -6142,8 +5829,7 @@ cat /etc/passwd | cut -f3 -d":" | sort -n | uniq -c | while read x ; do
 set - $x
 if [ $1 -gt 1 ]; then
 users=`awk -F: '($3 == n) { print $1 }' n=$2 /etc/passwd | xargs`
-echo "Duplicate UID ($2): ${users}"
-fi
+fiecho "Duplicate UID ($2): ${users}"
 done
 Remediation:
 Based on the results of the audit script, establish unique UIDs and review all files owned by
@@ -6154,8 +5840,8 @@ the shared UIDs to determine which UID they are supposed to belong to.
 6.2.17 Ensure no duplicate GIDs exist (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-Although the groupadd program will not let you create a duplicate Group ID (GID), it is
-possible for an administrator to manually edit the /etc/group file and change the GID
+Although the groupadd  program will not let you create a duplicate Group ID (GID), it is
+possible for an administrator to manually edit the/etc/group  file and change the GID
 field.
 Rationale:
 User groups must be assigned unique GIDs for accountability and to ensure appropriate
@@ -6168,8 +5854,7 @@ cat /etc/group | cut -f3 -d":" | sort -n | uniq -c | while read x ; do
 set - $x
 if [ $1 -gt 1 ]; then
 groups=`awk -F: '($3 == n) { print $1 }' n=$2 /etc/group | xargs`
-echo "Duplicate GID ($2): ${groups}"
-fi
+fiecho "Duplicate GID ($2): ${groups}"
 done
 Remediation:
 Based on the results of the audit script, establish unique GIDs and review all files owned by
@@ -6183,11 +5868,11 @@ file.
 6.2.18 Ensure no duplicate user names exist (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-Although the useradd program will not let you create a duplicate user name, it is possible
-for an administrator to manually edit the /etc/passwd file and change the user name.
+Although the useradd  program will not let you create a duplicate user name, it is possible
+for an administrator to manually edit the/etc/passwd  file and change the user name.
 Rationale:
 If a user is assigned a duplicate user name, it will create and have access to files with the
-first UID for that username in /etc/passwd. For example, if "test4" has a UID of 1000 and a
+first UID for that username in/etc/passwd . For example, if "test4" has a UID of 1000 and a
 subsequent "test4" entry has a UID of 2000, logging in as "test4" will use UID 1000.
 Effectively, the UID is shared, which is a security problem.
 Audit:
@@ -6210,12 +5895,12 @@ ownerships will automatically reflect the change as long as the users have uniqu
 6.2.19 Ensure no duplicate group names exist (Scored)
 Profile Applicability: Level 1 - Server Level 1 - Workstation
 Description:
-Although the groupadd program will not let you create a duplicate group name, it is
-possible for an administrator to manually edit the /etc/group file and change the group
+Although the groupadd  program will not let you create a duplicate group name, it is
+possible for an administrator to manually edit the/etc/group file and change the group
 name.
 Rationale:
 If a group is assigned a duplicate group name, it will create and have access to files with the
-first GID for that group in /etc/group. Effectively, the GID is shared, which is a security
+first GID for that group i/etc/group . Effectively, the GID is shared, which is a security
 problem.
 Audit:
 Run the following script and verify no results are returned:
@@ -6242,9 +5927,9 @@ The shadow group allows system programs which require access the ability to read
 /etc/shadow file. No users should be assigned to the shadow group.
 Rationale:
 Any users assigned to the shadow group would be granted read access to the /etc/shadow
-file. If attackers can gain read access to the /etc/shadow file, they can easily run a
+file. If attackers can gain read access to /etc/shadow  file, they can easily run a
 password cracking program against the hashed passwords to break them. Other security
-information that is stored in the /etc/shadow file (such as expiration) could also be useful
+information that is stored in th/etc/shadow  file (such as expiration) could also be useful
 to subvert additional user accounts.
 Audit:
 Run the following commands and verify no results are returned:

--- a/lib/inspec_tools/pdf.rb
+++ b/lib/inspec_tools/pdf.rb
@@ -102,6 +102,7 @@ module InspecTools
 
     def read_pdf
       @pdf_text = Util::ExtractPdfText.new(@pdf).extracted_text
+      write_pdf_text if @debug
     end
 
     def clean_pdf_text
@@ -111,6 +112,10 @@ module InspecTools
 
     def transform_data
       @transformed_data = Util::PrepareData.new(@clean_text).transformed_data
+    end
+
+    def write_pdf_text
+      File.write('lib/data/pdf_text', @pdf_text)
     end
 
     def write_clean_text

--- a/lib/inspec_tools/version.rb
+++ b/lib/inspec_tools/version.rb
@@ -1,3 +1,3 @@
 module InspecTools
-  VERSION = '1.1.3'.freeze
+  VERSION = '1.1.4'.freeze
 end

--- a/lib/utilities/extract_pdf_text.rb
+++ b/lib/utilities/extract_pdf_text.rb
@@ -1,4 +1,4 @@
-require 'docsplit'
+require "pdf-reader"
 
 module Util
   class ExtractPdfText
@@ -11,16 +11,11 @@ module Util
     attr_reader :extracted_text
 
     def read_text
-      Docsplit.extract_text([@pdf.path], ocr: false, output: Dir.tmpdir)
-      txt_file = File.basename(@pdf.path, File.extname(@pdf.path)) + '.txt'
-      txt_filename = Dir.tmpdir + '/' + txt_file
-
-      File.open(txt_filename).each do |line|
-        line = line.strip.gsub(/\A\p{Space}*|\p{Space}*\z/, '') + "\n"
-        line = line.gsub(/\p{Space}{2}/, ' ')
-        @extracted_text += line
+      reader = PDF::Reader.new(@pdf.path)
+      reader.pages.each do |page|
+        @extracted_text += page.text
       end
-      File.delete(txt_filename)
     end
+
   end
 end

--- a/lib/utilities/text_cleaner.rb
+++ b/lib/utilities/text_cleaner.rb
@@ -21,6 +21,8 @@ module Util
 
     # Removes everything before and after the controls
     def isolate_controls_data(extracted_data)
+      extracted_data = extracted_data.gsub(/\| P a g e+/, "| P a g e\n")
+      extracted_data = extracted_data.split("\n").map{ |line| line.strip}.reject { |e| e.to_s.empty? }.join("\n")
       extracted_data = extracted_data.gsub('???', '')
       controls_data = /^1\.1\s*[^\)]*?(?=\)$)(.*\n)*?(?=\s*Appendix:)/.match(extracted_data).to_s
       controls_data

--- a/test/unit/inspec_tools/pdf_test.rb
+++ b/test/unit/inspec_tools/pdf_test.rb
@@ -17,7 +17,7 @@ class PDFTest < Minitest::Test
 
   def test_pdf_to_inspec
     pdf = File.open('examples/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0.pdf')
-    pdf_tool = InspecTools::PDF.new(pdf, 'test', false)
+    pdf_tool = InspecTools::PDF.new(pdf, 'test', true)
     inspec_json = pdf_tool.to_inspec
     assert(inspec_json)
   end


### PR DESCRIPTION
The docsplit gem has a dependency on a command-line tool which does not work on Windows systems, and pdf-reader does not.