### PR TITLE
Null Byte in json report causes inspec2ckl to bomb-out

### DIFF
--- a/lib/inspec_tools/inspec.rb
+++ b/lib/inspec_tools/inspec.rb
@@ -18,7 +18,7 @@ require_relative 'csv'
 module InspecTools
   class Inspec
     def initialize(inspec_json, metadata = '{}')
-      @json = JSON.parse(inspec_json)
+      @json = JSON.parse(inspec_json.gsub(/\\+u0000/,''))
       @metadata = JSON.parse(metadata)
     end
 

--- a/lib/inspec_tools/inspec.rb
+++ b/lib/inspec_tools/inspec.rb
@@ -18,7 +18,7 @@ require_relative 'csv'
 module InspecTools
   class Inspec
     def initialize(inspec_json, metadata = '{}')
-      @json = JSON.parse(inspec_json.gsub(/\\+u0000/,''))
+      @json = JSON.parse(inspec_json.gsub(/\\+u0000/, ''))
       @metadata = JSON.parse(metadata)
     end
 


### PR DESCRIPTION
In some controls/resources inspec allows the \u0000 null byte to exist in the json report.  xml will bomb-out if this exists thus we must filter it.

Signed-off-by: Kevin J. Smith <kevin.j.smith2@cerner.com>
