### PR TITLE
Fix https://public.cyber.mil refernces

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           bundle install
       - name: Run rake test
         run: |
-          rake test
+          bundle exec rake test
 #      - name: Install rubocop
 #        run: |
 #          gem install rubocop
@@ -27,7 +27,7 @@ jobs:
 #        run: |
 #          rubocop
       - name: Build inspec_tools gem
-        run: | 
+        run: |
           gem build inspec_tools.gemspec
       - name: Install inspec_tools gem
         run: |

--- a/README.md
+++ b/README.md
@@ -261,7 +261,7 @@ USAGE: inspec_tools version
 
 This gem was developed using the [CLI Template](https://github.com/tongueroo/cli-template), a generator tool that builds a starter CLI project.
 
-## A complete PR should include 7 core elements:  
+## A complete PR should include 7 core elements:
 
 - A signed PR ( aka `git commit -a -s` )
 - Code for the new functionality
@@ -291,7 +291,7 @@ This gem was developed using the [CLI Template](https://github.com/tongueroo/cli
 17. git commit -a -s `<your_branch>`
 18. Open a PRs aginst the MITRE inspec_tools repo
 
-# Testing  
+# Testing
 
 There are a set of unit tests. Run `rake test` to run the tests.
 
@@ -313,4 +313,4 @@ MITRE hereby grants express written permission to use, reproduce, distribute, mo
 
 This software was produced for the U. S. Government under Contract Number HHSM-500-2012-00008I, and is subject to Federal Acquisition Regulation Clause 52.227-14, Rights in Data-General.
 
-No other use other than that granted to the U. S. Government, or to those acting on behalf of the U. S. Government under that Clause is authorized without the express written permission of The MITRE Corporation.DISA STIGs are published by DISA IASE, see: https://iase.disa.mil/Pages/privacy_policy.aspx
+No other use other than that granted to the U. S. Government, or to those acting on behalf of the U. S. Government under that Clause is authorized without the express written permission of The MITRE Corporation. DISA STIGs are published by DISA, see: https://public.cyber.mil/privacy-security/

--- a/lib/data/README.TXT
+++ b/lib/data/README.TXT
@@ -18,7 +18,7 @@ singular, actionable statements that comprise an IA control or IA best practice.
   - Stylesheet for viewing CCI List as HTML
     (open U_CCI_List.xml in a web browser to view)
 
-see: https://iase.disa.mil/stigs/cci/pages/index.aspx
+see: https://public.cyber.mil/stigs/cci/
 
 * NIST_Map_09212017B_CSC-CIS_Critical_Security_Controls_VER_6.1_Excel_9.1.2016.xlsx
 

--- a/lib/data/attributes.yml
+++ b/lib/data/attributes.yml
@@ -1,23 +1,24 @@
 ---
 benchmark.title: PostgreSQL 9.x Security Technical Implementation Guide
 benchmark.id: PostgreSQL_9-x_STIG
-benchmark.description: 'This Security Technical Implementation Guide is published
+benchmark.description:
+  "This Security Technical Implementation Guide is published
   as a tool to improve the security of Department of Defense (DoD) information systems.
   The requirements are derived from the National Institute of Standards and Technology
   (NIST) 800-53 and related documents. Comments or proposed revisions to this document
-  should be sent via email to the following address: disa.stig_spt@mail.mil.'
-benchmark.version: '1'
+  should be sent via email to the following address: disa.stig_spt@mail.mil."
+benchmark.version: "1"
 benchmark.status: accepted
-benchmark.status.date: '2017-01-20'
+benchmark.status.date: "2017-01-20"
 benchmark.notice.id: terms-of-use
-benchmark.plaintext: 'Release: 1 Benchmark Date: 20 Jan 2017'
+benchmark.plaintext: "Release: 1 Benchmark Date: 20 Jan 2017"
 benchmark.plaintext.id: release-info
-reference.href: http://iase.disa.mil
+reference.href: https://public.cyber.mil/
 reference.dc.publisher: DISA
 reference.dc.source: STIG.DOD.MIL
 reference.dc.title: DPMS Target PostgreSQL 9.x
 reference.dc.subject: PostgreSQL 9.x
 reference.dc.type: DPMS Target
-reference.dc.identifier: '3087'
+reference.dc.identifier: "3087"
 content_ref.name: M
 content_ref.href: DPMS_XCCDF_Benchmark_PostgreSQL_9-x_STIG.xml

--- a/lib/inspec_tools/inspec.rb
+++ b/lib/inspec_tools/inspec.rb
@@ -300,7 +300,7 @@ module InspecTools
         group.rule.reference.dc_identifier = @attribute['reference.dc.identifier']
 
         group.rule.ident = HappyMapperTools::Benchmark::Ident.new
-        group.rule.ident.system = 'http://iase.disa.mil/cci'
+        group.rule.ident.system = 'https://public.cyber.mil/stigs/cci/'
         group.rule.ident.ident = control['cci']
 
         group.rule.fixtext = HappyMapperTools::Benchmark::Fixtext.new


### PR DESCRIPTION
Update to reference https://public.cyber.mil

Fixes #66

Signed-off-by: Aaron Lippold <lippold@gmail.com>