### PR TITLE
Fixes #77 by shifting help commands around

### DIFF
--- a/lib/inspec_tools/plugin_cli.rb
+++ b/lib/inspec_tools/plugin_cli.rb
@@ -248,7 +248,7 @@ ARGV.push("--log-directory=#{Dir.pwd}/logs") if (log_commands & ARGV).empty? && 
 # Push help to front of command so thor recognizes subcommands are called with help
 if help_commands.any? { |cmd| ARGV.include? cmd }
   help_commands.each do |cmd|
-    if match = ARGV.delete(cmd)
+    if (match = ARGV.delete(cmd))
       ARGV.unshift match
     end
   end

--- a/lib/inspec_tools/plugin_cli.rb
+++ b/lib/inspec_tools/plugin_cli.rb
@@ -245,4 +245,13 @@ end
 #---------------------------------------------------------------------#
 ARGV.push("--log-directory=#{Dir.pwd}/logs") if (log_commands & ARGV).empty? && (help_commands & ARGV).empty?
 
+# Push help to front of command so thor recognizes subcommands are called with help
+if help_commands.any? { |cmd| ARGV.include? cmd }
+  help_commands.each do |cmd|
+    if match = ARGV.delete(cmd)
+      ARGV.unshift match
+    end
+  end
+end
+
 # rubocop:enable Style/GuardClause


### PR DESCRIPTION
Resolves #77 by reordering -h and other help flags, I believe this does mean that you cannot pass help as an argument to any command. If that is an issue this PR should be rejected.

Signed-off-by: Luke Malinowski <lmalinowski@mitre.org>