### PR TITLE
Fix bug in creating severity override guidance tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,10 @@ jobs:
       matrix:
         platform: [ubuntu-latest, macos-latest, windows-latest]
         ruby: [ '2.4', '2.5', '2.6', '2.7']
+        # TODO: Remove this exclusion once Nokogiri is supported on ruby 2.7 for Windows
+        exclude:
+          - platform: windows-latest
+            ruby: 2.7
     runs-on: ${{ matrix.platform }}
     steps:
       - name: Checkout inspec_tools

--- a/lib/utilities/inspec_util.rb
+++ b/lib/utilities/inspec_util.rb
@@ -298,7 +298,7 @@ module Utils
         control.add_tag(::Inspec::Object::Tag.new('false_positives', json_control['tags']['false_positives'])) unless json_control['tags']['false_positives'].blank?
         control.add_tag(::Inspec::Object::Tag.new('documentable', json_control['tags']['documentable'])) unless json_control['tags']['documentable'].blank?
         control.add_tag(::Inspec::Object::Tag.new('mitigations', json_control['tags']['mitigations'])) unless json_control['tags']['mitigations'].blank?
-        control.add_tag(::Inspec::Object::Tag.new('severity_override_guidance', json_control['tags']['documentable'])) unless json_control['tags']['severity_override_guidance'].blank?
+        control.add_tag(::Inspec::Object::Tag.new('severity_override_guidance', json_control['tags']['severity_override_guidance'])) unless json_control['tags']['severity_override_guidance'].blank?
         control.add_tag(::Inspec::Object::Tag.new('potential_impacts', json_control['tags']['potential_impacts'])) unless json_control['tags']['potential_impacts'].blank?
         control.add_tag(::Inspec::Object::Tag.new('third_party_tools', json_control['tags']['third_party_tools'])) unless json_control['tags']['third_party_tools'].blank?
         control.add_tag(::Inspec::Object::Tag.new('mitigation_controls', json_control['tags']['mitigation_controls'])) unless json_control['tags']['mitigation_controls'].blank?


### PR DESCRIPTION
Fix bug in creating severity override guidance tags

Exclude Windows with Ruby 2.7 from running for the time being because nokogiri does not support Ruby 2.7 on Windows currently