### PR TITLE
Ruby 2.6.6 and 2.7.1 update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Fetch all tags for versioning
         run: git fetch origin +refs/tags/*:refs/tags/*
       - name: Setup Ruby ${{ matrix.ruby }}
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
       - name: Install bundler and git-lite-version-bump

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
       matrix:
         platform: [ubuntu-16.04, ubuntu-latest, macos-latest, windows-latest]
-        ruby: [ 2.4, 2.5, 2.6, 2.7 ]
+        ruby: [ 2.5, 2.6, 2.7 ]
         # TODO: Remove this exclusion once Nokogiri is supported on ruby 2.7 for Windows
         exclude:
           - platform: windows-latest

--- a/inspec_tools.gemspec
+++ b/inspec_tools.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.executables   << 'inspec_tools'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.4'
+  spec.required_ruby_version = '~> 2.5'
 
   spec.add_runtime_dependency 'colorize', '~> 0'
   spec.add_runtime_dependency 'inspec', ">= 4.18.100", "< 5.0"


### PR DESCRIPTION
- Drops Support for Ruby 2.4
- Migrates GH Actions to `ruby/setup-ruby` for latest version compatibility so we can run our CI/build on 2.6.6 and 2.7.1