### PR TITLE
Missing array type for replace_tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,7 +50,7 @@ jobs:
           inspec_tools summary -j examples/sample_json/rhel-simp.json -o summary.json -c
           inspec_tools csv2inspec -c examples/csv2inspec/stig.csv -m examples/csv2inspec/mapping.yml -o csv2inspec_test
           inspec_tools xccdf2inspec -x examples/xccdf2inspec/xccdf.xml -a lib/data/attributes.yml -o xccdf2inspec_test
-          inspec_tools xccdf2inspec -x examples/xccdf2inspec/data/U_JBOSS_EAP_6-3_STIG_V1R2_Manual-xccdf.xml -o xccdf2inspec_replace_test -r DIAGNOSTIC_DEST
+          inspec_tools xccdf2inspec -x examples/xccdf2inspec/data/U_JBOSS_EAP_6-3_STIG_V1R2_Manual-xccdf.xml -o xccdf2inspec_replace_test -r JBOSS_HOME
           inspec_tools pdf2inspec -p examples/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0.pdf -o pdf2inspec_test
           inspec_tools inspec2csv -j examples/sample_json/rhel-simp.json -o inspec2csv_test.csv
           inspec_tools inspec2ckl -j examples/sample_json/rhel-simp.json -o inspec2ckl_test.ckl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,7 @@ jobs:
           inspec_tools summary -j examples/sample_json/rhel-simp.json -o summary.json -c
           inspec_tools csv2inspec -c examples/csv2inspec/stig.csv -m examples/csv2inspec/mapping.yml -o csv2inspec_test
           inspec_tools xccdf2inspec -x examples/xccdf2inspec/xccdf.xml -a lib/data/attributes.yml -o xccdf2inspec_test
+          inspec_tools xccdf2inspec -x examples/xccdf2inspec/data/U_JBOSS_EAP_6-3_STIG_V1R2_Manual-xccdf.xml -o xccdf2inspec_replace_test -r DIAGNOSTIC_DEST
           inspec_tools pdf2inspec -p examples/CIS_Ubuntu_Linux_16.04_LTS_Benchmark_v1.0.0.pdf -o pdf2inspec_test
           inspec_tools inspec2csv -j examples/sample_json/rhel-simp.json -o inspec2csv_test.csv
           inspec_tools inspec2ckl -j examples/sample_json/rhel-simp.json -o inspec2ckl_test.ckl

--- a/lib/inspec_tools/plugin_cli.rb
+++ b/lib/inspec_tools/plugin_cli.rb
@@ -35,7 +35,7 @@ module InspecPlugins
       option :output, required: false, aliases: '-o', default: 'profile'
       option :format, required: false, aliases: '-f', enum: %w{ruby hash}, default: 'ruby'
       option :separate_files, required: false, type: :boolean, default: true, aliases: '-s'
-      option :replace_tags, required: false, aliases: '-r'
+      option :replace_tags, type: :array, required: false, aliases: '-r'
       option :metadata, required: false, aliases: '-m'
       def xccdf2inspec
         xccdf = InspecTools::XCCDF.new(File.read(options[:xccdf]), options[:replace_tags])


### PR DESCRIPTION
### How to reproduce error
Try to use the `--replace-tags` flag with the `xccdf2inspec` command:

```
xccdf2inspec -x U_Oracle_Database_11-2g_STIG_V1R18_Manual-xccdf.xml -o myprofile  -r DIAGNOSTIC_DEST
```
### Fix
The `replace_tags` cli option for the `xccdf2inspec` command is missing the `type: :array` which would lead to String error when trying to use that flag. This fix allows you to successfully use the `replace_tags` cli option.


