### PR TITLE
Break CCI Vuln Information into separate StigData

### DIFF
--- a/lib/happy_mapper_tools/stig_checklist.rb
+++ b/lib/happy_mapper_tools/stig_checklist.rb
@@ -42,6 +42,12 @@ module HappyMapperTools
     # Class Asset maps from the 'STIG_DATA' from Checklist XML file using HappyMapper
     class StigData
       include HappyMapper
+
+      def initialize(attrib=nil, data=nil)
+        self.attrib = attrib
+        self.data = data
+      end
+
       tag 'STIG_DATA'
       has_one :attrib, String, tag: 'VULN_ATTRIBUTE'
       has_one :data, String, tag: 'ATTRIBUTE_DATA'

--- a/lib/happy_mapper_tools/stig_checklist.rb
+++ b/lib/happy_mapper_tools/stig_checklist.rb
@@ -43,7 +43,7 @@ module HappyMapperTools
     class StigData
       include HappyMapper
 
-      def initialize(attrib=nil, data=nil)
+      def initialize(attrib = nil, data = nil)
         self.attrib = attrib
         self.data = data
       end

--- a/lib/inspec_tools/inspec.rb
+++ b/lib/inspec_tools/inspec.rb
@@ -144,7 +144,7 @@ module InspecTools
       vuln = HappyMapperTools::StigChecklist::Vuln.new
       stig_data_list = []
 
-      %w[Vuln_Num Group_Title Rule_ID Rule_Ver Rule_Title Vuln_Discuss Check_Content Fix_Text].each do |attribute|
+      %w{Vuln_Num Group_Title Rule_ID Rule_Ver Rule_Title Vuln_Discuss Check_Content Fix_Text}.each do |attribute|
         stig_data_list << create_stig_data_element(attribute, control)
       end
       stig_data_list << handle_severity(control)
@@ -313,7 +313,7 @@ module InspecTools
     end
 
     def handle_cci_ref(control)
-      return if control[:cci_ref].nil?
+      return [] if control[:cci_ref].nil?
 
       cci_data = []
       if control[:cci_ref].respond_to?(:each)

--- a/lib/inspec_tools/inspec.rb
+++ b/lib/inspec_tools/inspec.rb
@@ -305,10 +305,7 @@ module InspecTools
     def handle_vuln_num(stig_data_list, control)
       return stig_data_list if control[:vuln_num].nil?
 
-      stig_data = HappyMapperTools::StigChecklist::StigData.new
-      stig_data.attrib = 'Vuln_Num'
-      stig_data.data = control[:vuln_num]
-      stig_data_list.push(stig_data)
+      stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('Vuln_Num', control[:vuln_num]))
     end
 
     def handle_severity(stig_data_list, control)
@@ -319,93 +316,67 @@ module InspecTools
 
       value = 'high' if value == 'critical'
 
-      stig_data = HappyMapperTools::StigChecklist::StigData.new
-      stig_data.attrib = 'Severity'
-      stig_data.data = value
-      stig_data_list.push(stig_data)
+      stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('Severity', value))
     end
 
     def handle_group_title(stig_data_list, control)
       return stig_data_list if control[:group_title].nil?
 
-      stig_data = HappyMapperTools::StigChecklist::StigData.new
-      stig_data.attrib = 'Group_Title'
-      stig_data.data = control[:group_title]
-      stig_data_list.push(stig_data)
+      stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('Group_Title', control[:group_title]))
     end
 
     def handle_rule_id(stig_data_list, control)
       return stig_data_list if control[:rule_id].nil?
 
-      stig_data = HappyMapperTools::StigChecklist::StigData.new
-      stig_data.attrib = 'Rule_ID'
-      stig_data.data = control[:rule_id]
-      stig_data_list.push(stig_data)
+      stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('Rule_ID', control[:rule_id]))
     end
 
     def handle_rule_ver(stig_data_list, control)
       return stig_data_list if control[:rule_ver].nil?
 
-      stig_data = HappyMapperTools::StigChecklist::StigData.new
-      stig_data.attrib = 'Rule_Ver'
-      stig_data.data = control[:rule_ver]
-      stig_data_list.push(stig_data)
+      stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('Rule_Ver', control[:rule_ver]))
     end
 
     def handle_rule_title(stig_data_list, control)
       return stig_data_list if control[:rule_title].nil?
 
-      stig_data = HappyMapperTools::StigChecklist::StigData.new
-      stig_data.attrib = 'Rule_Title'
-      stig_data.data = control[:rule_title]
-      stig_data_list.push(stig_data)
+      stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('Rule_Title', control[:rule_title]))
     end
 
 
     def handle_vuln_discuss(stig_data_list, control)
       return stig_data_list if control[:vuln_discuss].nil?
 
-      stig_data = HappyMapperTools::StigChecklist::StigData.new
-      stig_data.attrib = 'Vuln_Discuss'
-      stig_data.data = control[:vuln_discuss]
-      stig_data_list.push(stig_data)
+      stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('Vuln_Discuss', control[:vuln_discuss]))
     end
 
     def handle_check_content(stig_data_list, control)
       return stig_data_list if control[:check_content].nil?
 
-      stig_data = HappyMapperTools::StigChecklist::StigData.new
-      stig_data.attrib = 'Check_Content'
-      stig_data.data = control[:check_content]
-      stig_data_list.push(stig_data)
+      stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('Check_Content', control[:check_content]))
     end
 
     def handle_fix_text(stig_data_list, control)
       return stig_data_list if control[:fix_text].nil?
 
-      stig_data = HappyMapperTools::StigChecklist::StigData.new
-      stig_data.attrib = 'Fix_Text'
-      stig_data.data = control[:fix_text]
-      stig_data_list.push(stig_data)
+      stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('Fix_Text', control[:fix_text]))
     end
 
     def handle_cci_ref(stig_data_list, control)
       return stig_data_list if control[:cci_ref].nil?
 
-      control[:cci_ref].each do |cci_number|
-        stig_data = HappyMapperTools::StigChecklist::StigData.new
-        stig_data.attrib = 'CCI_REF'
-        stig_data.data = cci_number
-        stig_data_list.push(stig_data)
+      if control[:cci_ref].respond_to?(:each)
+        control[:cci_ref].each do |cci_number|
+          stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('CCI_REF', cci_number))
+        end
+        stig_data_list
+      else
+        stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('CCI_REF', control[:cci_ref]))
       end
-      stig_data_list
     end
 
     def handle_stigref(stig_data_list)
-      stig_data = HappyMapperTools::StigChecklist::StigData.new
-      stig_data.attrib = 'STIGRef'
-      stig_data.data = @title
-      stig_data_list.push(stig_data)
+      stig_data_list.push(HappyMapperTools::StigChecklist::StigData.new('STIGRef', @title))
     end
   end
 end


### PR DESCRIPTION
Fixes an issue seen in version 2.10 of STIGViewer where inspec_tools generates CKL files that do not display CCI info correctly.

closes #147 