### PR TITLE
Standardize Output of Severity and Impact to CVSS v3.0 terms

### DIFF
--- a/lib/inspec_tools/csv.rb
+++ b/lib/inspec_tools/csv.rb
@@ -90,7 +90,10 @@ module InspecTools
         @mapping['control.tags'].each do |tag|
           control['tags'][tag.first.to_s] = row[tag.last] unless row[tag.last].nil?
         end
-        control['impact'] = Utils::InspecUtil.get_impact(row[@mapping['control.tags']['severity']]) unless @mapping['control.tags']['severity'].nil? || row[@mapping['control.tags']['severity']].nil?
+        unless @mapping['control.tags']['severity'].nil? || row[@mapping['control.tags']['severity']].nil?
+          control['impact'] = Utils::InspecUtil.get_impact(row[@mapping['control.tags']['severity']])
+          control['tags']['severity'] = Utils::InspecUtil.get_impact_string(control['impact'])
+        end
         @controls << control
       end
     end

--- a/lib/inspec_tools/inspec.rb
+++ b/lib/inspec_tools/inspec.rb
@@ -304,10 +304,8 @@ module InspecTools
     def handle_severity(control)
       return if control[:impact].nil?
 
-      value = Utils::InspecUtil.get_impact_string(control[:impact])
+      value = Utils::InspecUtil.get_impact_string(control[:impact], false)
       return if value == 'none'
-
-      value = 'high' if value == 'critical'
 
       HappyMapperTools::StigChecklist::StigData.new('Severity', value)
     end

--- a/lib/inspec_tools/inspec.rb
+++ b/lib/inspec_tools/inspec.rb
@@ -304,7 +304,7 @@ module InspecTools
     def handle_severity(control)
       return if control[:impact].nil?
 
-      value = Utils::InspecUtil.get_impact_string(control[:impact], false)
+      value = Utils::InspecUtil.get_impact_string(control[:impact], use_cvss_terms: false)
       return if value == 'none'
 
       HappyMapperTools::StigChecklist::StigData.new('Severity', value)

--- a/lib/inspec_tools/pdf.rb
+++ b/lib/inspec_tools/pdf.rb
@@ -65,6 +65,7 @@ module InspecTools
         control['desc'] = contr[:descr]
         control['impact'] = Utils::InspecUtil.get_impact('medium')
         control['tags'] = {}
+        control['tags']['severity'] = Utils::InspecUtil.get_impact_string(control['impact'])
         control['tags']['ref'] = contr[:ref] unless contr[:ref].nil?
         control['tags']['applicability'] = contr[:applicability] unless contr[:applicability].nil?
         control['tags']['cis_id'] = contr[:title].split(' ')[0] unless contr[:title].nil?

--- a/lib/inspec_tools/xccdf.rb
+++ b/lib/inspec_tools/xccdf.rb
@@ -126,6 +126,7 @@ module InspecTools
         control['desc'] = group.rule.description.vuln_discussion.split('Satisfies: ')[0]
         control['impact'] = Utils::InspecUtil.get_impact(group.rule.severity)
         control['tags'] = {}
+        control['tags']['severity'] = Utils::InspecUtil.get_impact_string(control['impact'])
         control['tags']['gtitle'] = group.title
         control['tags']['satisfies'] = group.rule.description.vuln_discussion.split('Satisfies: ')[1].split(',').map(&:strip) if group.rule.description.vuln_discussion.split('Satisfies: ').length > 1
         control['tags']['gid'] = group.id

--- a/lib/utilities/inspec_util.rb
+++ b/lib/utilities/inspec_util.rb
@@ -191,7 +191,7 @@ module Utils
     # @todo Allow for the user to pass in a hash for the desired mapping of text
     # values to numbers or to override our hard coded values.
     #
-    def self.get_impact(severity, use_cvss_terms = true)
+    def self.get_impact(severity, use_cvss_terms: true)
       return float_to_impact(severity, use_cvss_terms) if severity.is_a?(Float)
 
       return string_to_impact(severity, use_cvss_terms) if severity.is_a?(String)
@@ -238,7 +238,7 @@ module Utils
       impact == 1.0 && use_cvss_terms ? 0.7 : impact
     end
 
-    def self.get_impact_string(impact, use_cvss_terms = true)
+    def self.get_impact_string(impact, use_cvss_terms: true)
       return if impact.nil?
 
       value = impact.to_f

--- a/lib/utilities/inspec_util.rb
+++ b/lib/utilities/inspec_util.rb
@@ -16,7 +16,6 @@ require 'overrides/string'
 # rubocop:disable Metrics/AbcSize
 # rubocop:disable Metrics/PerceivedComplexity
 # rubocop:disable Metrics/CyclomaticComplexity
-# rubocop:disable Metrics/BlockLength
 # rubocop:disable Metrics/MethodLength
 
 module Utils
@@ -46,7 +45,7 @@ module Utils
       end
       c_data = {}
 
-      controls.each do |control| # rubocop:disable Metrics/BlockLength
+      controls.each do |control|
         c_id = control['id'].to_sym
         c_data[c_id] = {}
         c_data[c_id]['id']             = control['id']    || DATA_NOT_FOUND_MESSAGE
@@ -192,18 +191,20 @@ module Utils
     # @todo Allow for the user to pass in a hash for the desired mapping of text
     # values to numbers or to override our hard coded values.
     #
-    def self.get_impact(severity)
-      return float_to_impact(severity) if severity.is_a?(Float)
+    def self.get_impact(severity, use_cvss_terms = true)
+      return float_to_impact(severity, use_cvss_terms) if severity.is_a?(Float)
 
-      return string_to_impact(severity) if severity.is_a?(String)
+      return string_to_impact(severity, use_cvss_terms) if severity.is_a?(String)
 
       raise SeverityInputError, "'#{severity}' is not a valid severity value. It should be a Float between 0.0 and " \
                                 '1.0 or one of the approved keywords.'
     end
 
-    private_class_method def self.float_to_impact(severity)
-      raise SeverityInputError, "'#{severity}' is not a valid severity value. It should be a Float between 0.0 and " \
-                                  '1.0 or one of the approved keywords.' unless severity.between?(0, 1)
+    private_class_method def self.float_to_impact(severity, use_cvss_terms)
+      unless severity.between?(0, 1)
+        raise SeverityInputError, "'#{severity}' is not a valid severity value. It should be a Float between 0.0 and " \
+                                  '1.0 or one of the approved keywords.'
+      end
 
       if severity <= 0.01
         0.0 # Informative
@@ -211,31 +212,33 @@ module Utils
         0.3 # Low Impact
       elsif severity < 0.7
         0.5 # Medium Impact
-      elsif severity < 0.9
+      elsif severity < 0.9 || use_cvss_terms
         0.7 # High Impact
       else
         1.0 # Critical Controls
       end
     end
 
-    private_class_method def self.string_to_impact(severity)
+    private_class_method def self.string_to_impact(severity, use_cvss_terms)
       if /none|na|n\/a|not[_|(\s*)]?applicable/i.match?(severity)
-        0.0 # Informative
+        impact = 0.0 # Informative
       elsif /low|cat(egory)?\s*(iii|3)/i.match?(severity)
-        0.3 # Low Impact
+        impact = 0.3 # Low Impact
       elsif /med(ium)?|cat(egory)?\s*(ii|2)/i.match?(severity)
-        0.5 # Medium Impact
+        impact = 0.5 # Medium Impact
       elsif /high|cat(egory)?\s*(i|1)/i.match?(severity)
-        0.7 # High Impact
+        impact = 0.7 # High Impact
       elsif /crit(ical)?|severe/i.match?(severity)
-        1.0 # Critical Controls
+        impact = 1.0 # Critical Controls
       else
         raise SeverityInputError, "'#{severity}' is not a valid severity value. It should be a Float between 0.0 and " \
                                   '1.0 or one of the approved keywords.'
       end
+
+      impact == 1.0 && use_cvss_terms ? 0.7 : impact
     end
 
-    def self.get_impact_string(impact)
+    def self.get_impact_string(impact, use_cvss_terms = true)
       return if impact.nil?
 
       value = impact.to_f
@@ -243,8 +246,14 @@ module Utils
         raise ImpactInputError, "'#{value}' is not a valid impact score. Valid impact scores: [0.0 - 1.0]."
       end
 
-      IMPACT_SCORES.reverse_each do |name, impact|
-        return name if value >= impact
+      IMPACT_SCORES.reverse_each do |name, impact_score|
+        if name == 'critical' && value >= impact_score && use_cvss_terms
+          return 'high'
+        elsif value >= impact_score
+          return name
+        else
+          next
+        end
       end
     end
 
@@ -418,3 +427,9 @@ module Utils
     end
   end
 end
+
+# rubocop:enable Metrics/ClassLength
+# rubocop:enable Metrics/AbcSize
+# rubocop:enable Metrics/PerceivedComplexity
+# rubocop:enable Metrics/CyclomaticComplexity
+# rubocop:enable Metrics/MethodLength

--- a/test/unit/utils/inspec_util_test.rb
+++ b/test/unit/utils/inspec_util_test.rb
@@ -33,23 +33,23 @@ class InspecUtilTest < Minitest::Test
     # CVSS Terms False
 
     ['none' 'na' 'n/a' 'N/A' 'NONE' 'not applicable' 'not_applicable' 'NOT_APPLICABLE'].each do |word|
-      assert_equal(0.0, Utils::InspecUtil.get_impact(word, false))
+      assert_equal(0.0, Utils::InspecUtil.get_impact(word, use_cvss_terms: false))
     end
 
     ['low', 'cat iii', 'cat   iii', 'CATEGORY III', 'cat 3'].each do |word|
-      assert_equal(0.3, Utils::InspecUtil.get_impact(word, false))
+      assert_equal(0.3, Utils::InspecUtil.get_impact(word, use_cvss_terms: false))
     end
 
     ['medium', 'med', 'cat ii', 'cat   ii', 'CATEGORY II', 'cat 2'].each do |word|
-      assert_equal(0.5, Utils::InspecUtil.get_impact(word, false))
+      assert_equal(0.5, Utils::InspecUtil.get_impact(word, use_cvss_terms: false))
     end
 
     ['high', 'cat i', 'cat   i', 'CATEGORY I', 'cat 1'].each do |word|
-      assert_equal(0.7, Utils::InspecUtil.get_impact(word, false))
+      assert_equal(0.7, Utils::InspecUtil.get_impact(word, use_cvss_terms: false))
     end
 
     ['critical', 'crit', 'severe'].each do |word|
-      assert_equal(1.0, Utils::InspecUtil.get_impact(word, false))
+      assert_equal(1.0, Utils::InspecUtil.get_impact(word, use_cvss_terms: false))
     end
   end
 
@@ -67,16 +67,16 @@ class InspecUtilTest < Minitest::Test
     assert_equal(0.7, Utils::InspecUtil.get_impact(0.9))
 
     # CVSS Terms False
-    assert_equal(0.0, Utils::InspecUtil.get_impact(0.01, false))
-    assert_equal(0.3, Utils::InspecUtil.get_impact(0.1, false))
-    assert_equal(0.3, Utils::InspecUtil.get_impact(0.2, false))
-    assert_equal(0.3, Utils::InspecUtil.get_impact(0.3, false))
-    assert_equal(0.5, Utils::InspecUtil.get_impact(0.4, false))
-    assert_equal(0.5, Utils::InspecUtil.get_impact(0.5, false))
-    assert_equal(0.5, Utils::InspecUtil.get_impact(0.6, false))
-    assert_equal(0.7, Utils::InspecUtil.get_impact(0.7, false))
-    assert_equal(0.7, Utils::InspecUtil.get_impact(0.8, false))
-    assert_equal(1.0, Utils::InspecUtil.get_impact(0.9, false))
+    assert_equal(0.0, Utils::InspecUtil.get_impact(0.01, use_cvss_terms: false))
+    assert_equal(0.3, Utils::InspecUtil.get_impact(0.1, use_cvss_terms: false))
+    assert_equal(0.3, Utils::InspecUtil.get_impact(0.2, use_cvss_terms: false))
+    assert_equal(0.3, Utils::InspecUtil.get_impact(0.3, use_cvss_terms: false))
+    assert_equal(0.5, Utils::InspecUtil.get_impact(0.4, use_cvss_terms: false))
+    assert_equal(0.5, Utils::InspecUtil.get_impact(0.5, use_cvss_terms: false))
+    assert_equal(0.5, Utils::InspecUtil.get_impact(0.6, use_cvss_terms: false))
+    assert_equal(0.7, Utils::InspecUtil.get_impact(0.7, use_cvss_terms: false))
+    assert_equal(0.7, Utils::InspecUtil.get_impact(0.8, use_cvss_terms: false))
+    assert_equal(1.0, Utils::InspecUtil.get_impact(0.9, use_cvss_terms: false))
   end
 
   def test_get_impact_error
@@ -108,19 +108,19 @@ class InspecUtilTest < Minitest::Test
     assert_equal('high', Utils::InspecUtil.get_impact_string(1))
 
     # CVSS False
-    assert_equal('none', Utils::InspecUtil.get_impact_string(0, false))
-    assert_equal('none', Utils::InspecUtil.get_impact_string(0.01, false))
-    assert_equal('low', Utils::InspecUtil.get_impact_string(0.1, false))
-    assert_equal('low', Utils::InspecUtil.get_impact_string(0.2, false))
-    assert_equal('low', Utils::InspecUtil.get_impact_string(0.3, false))
-    assert_equal('medium', Utils::InspecUtil.get_impact_string(0.4, false))
-    assert_equal('medium' ,Utils::InspecUtil.get_impact_string(0.5, false))
-    assert_equal('medium', Utils::InspecUtil.get_impact_string(0.6, false))
-    assert_equal('high', Utils::InspecUtil.get_impact_string(0.7, false))
-    assert_equal('high', Utils::InspecUtil.get_impact_string(0.8, false))
-    assert_equal('critical', Utils::InspecUtil.get_impact_string(0.9, false))
-    assert_equal('critical', Utils::InspecUtil.get_impact_string(1.0, false))
-    assert_equal('critical', Utils::InspecUtil.get_impact_string(1, false))
+    assert_equal('none', Utils::InspecUtil.get_impact_string(0, use_cvss_terms: false))
+    assert_equal('none', Utils::InspecUtil.get_impact_string(0.01, use_cvss_terms: false))
+    assert_equal('low', Utils::InspecUtil.get_impact_string(0.1, use_cvss_terms: false))
+    assert_equal('low', Utils::InspecUtil.get_impact_string(0.2, use_cvss_terms: false))
+    assert_equal('low', Utils::InspecUtil.get_impact_string(0.3, use_cvss_terms: false))
+    assert_equal('medium', Utils::InspecUtil.get_impact_string(0.4, use_cvss_terms: false))
+    assert_equal('medium' ,Utils::InspecUtil.get_impact_string(0.5, use_cvss_terms: false))
+    assert_equal('medium', Utils::InspecUtil.get_impact_string(0.6, use_cvss_terms: false))
+    assert_equal('high', Utils::InspecUtil.get_impact_string(0.7, use_cvss_terms: false))
+    assert_equal('high', Utils::InspecUtil.get_impact_string(0.8, use_cvss_terms: false))
+    assert_equal('critical', Utils::InspecUtil.get_impact_string(0.9, use_cvss_terms: false))
+    assert_equal('critical', Utils::InspecUtil.get_impact_string(1.0, use_cvss_terms: false))
+    assert_equal('critical', Utils::InspecUtil.get_impact_string(1, use_cvss_terms: false))
   end
 
   def test_get_impact_string_error

--- a/test/unit/utils/inspec_util_test.rb
+++ b/test/unit/utils/inspec_util_test.rb
@@ -8,7 +8,8 @@ class InspecUtilTest < Minitest::Test
     refute_nil Utils::InspecUtil
   end
 
-  def test_get_impact_string
+  def test_string_to_impact
+    # CVSS Terms True
     ['none' 'na' 'n/a' 'N/A' 'NONE' 'not applicable' 'not_applicable' 'NOT_APPLICABLE'].each do |word|
       assert_equal(0.0, Utils::InspecUtil.get_impact(word))
     end
@@ -26,11 +27,34 @@ class InspecUtilTest < Minitest::Test
     end
 
     ['critical', 'crit', 'severe'].each do |word|
-      assert_equal(1.0, Utils::InspecUtil.get_impact(word))
+      assert_equal(0.7, Utils::InspecUtil.get_impact(word))
+    end
+
+    # CVSS Terms False
+
+    ['none' 'na' 'n/a' 'N/A' 'NONE' 'not applicable' 'not_applicable' 'NOT_APPLICABLE'].each do |word|
+      assert_equal(0.0, Utils::InspecUtil.get_impact(word, false))
+    end
+
+    ['low', 'cat iii', 'cat   iii', 'CATEGORY III', 'cat 3'].each do |word|
+      assert_equal(0.3, Utils::InspecUtil.get_impact(word, false))
+    end
+
+    ['medium', 'med', 'cat ii', 'cat   ii', 'CATEGORY II', 'cat 2'].each do |word|
+      assert_equal(0.5, Utils::InspecUtil.get_impact(word, false))
+    end
+
+    ['high', 'cat i', 'cat   i', 'CATEGORY I', 'cat 1'].each do |word|
+      assert_equal(0.7, Utils::InspecUtil.get_impact(word, false))
+    end
+
+    ['critical', 'crit', 'severe'].each do |word|
+      assert_equal(1.0, Utils::InspecUtil.get_impact(word, false))
     end
   end
 
-  def test_get_impact_float
+  def test_float_to_impact
+    # CVSS Terms True
     assert_equal(0.0, Utils::InspecUtil.get_impact(0.01))
     assert_equal(0.3, Utils::InspecUtil.get_impact(0.1))
     assert_equal(0.3, Utils::InspecUtil.get_impact(0.2))
@@ -40,7 +64,19 @@ class InspecUtilTest < Minitest::Test
     assert_equal(0.5, Utils::InspecUtil.get_impact(0.6))
     assert_equal(0.7, Utils::InspecUtil.get_impact(0.7))
     assert_equal(0.7, Utils::InspecUtil.get_impact(0.8))
-    assert_equal(1.0, Utils::InspecUtil.get_impact(0.9))
+    assert_equal(0.7, Utils::InspecUtil.get_impact(0.9))
+
+    # CVSS Terms False
+    assert_equal(0.0, Utils::InspecUtil.get_impact(0.01, false))
+    assert_equal(0.3, Utils::InspecUtil.get_impact(0.1, false))
+    assert_equal(0.3, Utils::InspecUtil.get_impact(0.2, false))
+    assert_equal(0.3, Utils::InspecUtil.get_impact(0.3, false))
+    assert_equal(0.5, Utils::InspecUtil.get_impact(0.4, false))
+    assert_equal(0.5, Utils::InspecUtil.get_impact(0.5, false))
+    assert_equal(0.5, Utils::InspecUtil.get_impact(0.6, false))
+    assert_equal(0.7, Utils::InspecUtil.get_impact(0.7, false))
+    assert_equal(0.7, Utils::InspecUtil.get_impact(0.8, false))
+    assert_equal(1.0, Utils::InspecUtil.get_impact(0.9, false))
   end
 
   def test_get_impact_error
@@ -52,6 +88,52 @@ class InspecUtilTest < Minitest::Test
     }
     assert_raises(Utils::InspecUtil::SeverityInputError) {
       Utils::InspecUtil.get_impact(9001.1)
+    }
+  end
+
+  def test_get_impact_string
+    # CVSS True
+    assert_equal('none', Utils::InspecUtil.get_impact_string(0))
+    assert_equal('none', Utils::InspecUtil.get_impact_string(0.01))
+    assert_equal('low', Utils::InspecUtil.get_impact_string(0.1))
+    assert_equal('low', Utils::InspecUtil.get_impact_string(0.2))
+    assert_equal('low', Utils::InspecUtil.get_impact_string(0.3))
+    assert_equal('medium', Utils::InspecUtil.get_impact_string(0.4))
+    assert_equal('medium' ,Utils::InspecUtil.get_impact_string(0.5))
+    assert_equal('medium', Utils::InspecUtil.get_impact_string(0.6))
+    assert_equal('high', Utils::InspecUtil.get_impact_string(0.7))
+    assert_equal('high', Utils::InspecUtil.get_impact_string(0.8))
+    assert_equal('high', Utils::InspecUtil.get_impact_string(0.9))
+    assert_equal('high', Utils::InspecUtil.get_impact_string(1.0))
+    assert_equal('high', Utils::InspecUtil.get_impact_string(1))
+
+    # CVSS False
+    assert_equal('none', Utils::InspecUtil.get_impact_string(0, false))
+    assert_equal('none', Utils::InspecUtil.get_impact_string(0.01, false))
+    assert_equal('low', Utils::InspecUtil.get_impact_string(0.1, false))
+    assert_equal('low', Utils::InspecUtil.get_impact_string(0.2, false))
+    assert_equal('low', Utils::InspecUtil.get_impact_string(0.3, false))
+    assert_equal('medium', Utils::InspecUtil.get_impact_string(0.4, false))
+    assert_equal('medium' ,Utils::InspecUtil.get_impact_string(0.5, false))
+    assert_equal('medium', Utils::InspecUtil.get_impact_string(0.6, false))
+    assert_equal('high', Utils::InspecUtil.get_impact_string(0.7, false))
+    assert_equal('high', Utils::InspecUtil.get_impact_string(0.8, false))
+    assert_equal('critical', Utils::InspecUtil.get_impact_string(0.9, false))
+    assert_equal('critical', Utils::InspecUtil.get_impact_string(1.0, false))
+    assert_equal('critical', Utils::InspecUtil.get_impact_string(1, false))
+  end
+
+  def test_get_impact_string_error
+    assert_raises(Utils::InspecUtil::ImpactInputError) {
+      Utils::InspecUtil.get_impact_string(9001)
+    }
+
+    assert_raises(Utils::InspecUtil::ImpactInputError) {
+      Utils::InspecUtil.get_impact_string(9001.1)
+    }
+
+    assert_raises(Utils::InspecUtil::ImpactInputError) {
+      Utils::InspecUtil.get_impact_string(-1)
     }
   end
 


### PR DESCRIPTION
Closes #107 

Adds a parameter to impact/severity generating functions to respect the CVSS terms or not, allowing the use of `critical` when converting to CKL format.

Adds tests for new parameters and `InspecUtils#get_impact_string` function.