### PR TITLE
Git version bump version 0.17.2 is broken due to a faulty regex.

### DIFF
--- a/inspec_tools.gemspec
+++ b/inspec_tools.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |spec| # rubocop:disable Metrics/BlockLength
   spec.add_runtime_dependency 'pdf-reader', '~> 2.1'
   spec.add_runtime_dependency 'roo', '~> 2.8'
   spec.add_runtime_dependency 'word_wrap', '~> 1.0'
-  spec.add_runtime_dependency 'git-lite-version-bump', '>= 0.17.2'
+  spec.add_runtime_dependency 'git-lite-version-bump', '>= 0.17.3'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Bumping to 0.17.3 which works.