### PR TITLE
Compliance score is rounded down and the README is updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ USAGE: inspec_tools generate_inspec_metadata
 
 If the specified threshold is not met, an error code (1) is returned along with non-compliant elements.
 
+The compliance score are rounded down to the nearest whole number. For example a score of 77.3 would be displayed as 77.
+
 ```
 USAGE:  inspec_tools compliance [OPTIONS] -j <inspec-json> -i <threshold-inline>
 	inspec_tools compliance [OPTIONS] -j <inspec-json> -f <threshold-file>

--- a/lib/inspec_tools/summary.rb
+++ b/lib/inspec_tools/summary.rb
@@ -83,7 +83,7 @@ module InspecTools
         (@summary[:status][:passed][:total]+
          @summary[:status][:failed][:total]+
          @summary[:status][:skipped][:total]+
-         @summary[:status][:error][:total])).round(1)
+         @summary[:status][:error][:total])).floor
     end
 
     def threshold_compliance

--- a/test/unit/inspec_tools/summary_test.rb
+++ b/test/unit/inspec_tools/summary_test.rb
@@ -37,6 +37,6 @@ class SummaryTest < Minitest::Test
     inspec_json = File.read('examples/sample_json/rhel-simp.json')
     threshold = YAML.safe_load('{compliance.min: 80, failed.critical.max: 0, failed.high.max: 0}')
     inspec_tools = InspecTools::Summary.new(inspec_json)
-    assert_output(%r{Expected compliance.min:80 got:77.3(\r\n|\r|\n)Expected failed.high.max:0 got:3}) { inspec_tools.threshold(threshold) }
+    assert_output(%r{Expected compliance.min:80 got:77(\r\n|\r|\n)Expected failed.high.max:0 got:3}) { inspec_tools.threshold(threshold) }
   end
 end

--- a/test/unit/inspec_tools/summary_test.rb
+++ b/test/unit/inspec_tools/summary_test.rb
@@ -22,7 +22,7 @@ class SummaryTest < Minitest::Test
     inspec_json = File.read('examples/sample_json/rhel-simp.json')
     inspec_tools = InspecTools::Summary.new(inspec_json)
     summary = inspec_tools.to_summary
-    assert_equal(77.3, summary[:compliance])
+    assert_equal(77, summary[:compliance])
     assert_equal(33, summary[:status][:failed][:medium])
   end
 


### PR DESCRIPTION
The compliance scores are rounded down to the floor instead of being kept as a decimal. 
closes #146 