### PR TITLE
fix inspec2ckl 'check_content' and 'fix_text' fields

### DIFF
--- a/lib/utilities/inspec_util.rb
+++ b/lib/utilities/inspec_util.rb
@@ -48,8 +48,8 @@ module Utils
           end
 
           if control['descriptions'].respond_to?(:find)
-            data[c_id][:check_content]  = control['descriptions'].find { |c| c['label'] == 'fix' }&.dig('data')
-            data[c_id][:fix_text]       = control['descriptions'].find { |c| c['label'] == 'check' }&.dig('data')
+            data[c_id][:check_content]  = control['descriptions'].find { |c| c['label'] == 'check' }&.dig('data')
+            data[c_id][:fix_text]       = control['descriptions'].find { |c| c['label'] == 'fix' }&.dig('data')
           end
 
           data[c_id][:impact]         = control['impact'].to_s unless control['impact'].nil?


### PR DESCRIPTION
`inspec_tools inspec2ckl` output has `Check Text:` and `Fix Text:` fields flipped.

This PR fixes this issue