### PR TITLE
Build latest tag on release as well

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,6 @@ jobs:
       matrix:
         platform: [ ubuntu-16.04, ubuntu-latest, macos-latest, windows-latest ]
         ruby: [ 2.5, 2.6, 2.7 ]
-        # TODO: Remove this exclusion once Nokogiri is supported on ruby 2.7 for Windows
-        exclude:
-          - platform: windows-latest
-            ruby: 2.7
     runs-on: ${{ matrix.platform }}
 
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,6 @@ jobs:
       - name: Log in to docker
         run: echo "${{secrets.DOCKERHUB_PASSWORD}}" | docker login -u ${{secrets.DOCKERHUB_USERNAME}} --password-stdin
       - name: Build container
-        run: docker build . --tag mitre/inspec_tools:$VERSION
+        run: docker build . --tag mitre/inspec_tools:$VERSION --tag mitre/inspec_tools:latest
       - name: Publish container to docker registry
-        run: docker push mitre/inspec_tools:$VERSION
+        run: docker push mitre/inspec_tools --all-tags

--- a/inspec_tools.gemspec
+++ b/inspec_tools.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |spec|
   spec.executables   << 'inspec_tools'
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.5'
+  spec.required_ruby_version = '>= 2.5'
 
   spec.add_runtime_dependency 'colorize', '~> 0'
   spec.add_runtime_dependency 'git-lite-version-bump', '>= 0.17.3'
@@ -43,7 +43,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'word_wrap', '~> 1.0'
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'bundler-audit'
-  spec.add_development_dependency 'codeclimate-test-reporter'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'minitest-reporters', '~> 1.4'
   spec.add_development_dependency 'pry'


### PR DESCRIPTION
Our current `latest` tag is very out of date.