### PR TITLE
Remove legacy V and SV identifiers from the CCI tags in xccdf2inspec

### DIFF
--- a/examples/xccdf2inspec/data/U_CAN_Ubuntu_18-04_STIG-xccdf.xml
+++ b/examples/xccdf2inspec/data/U_CAN_Ubuntu_18-04_STIG-xccdf.xml
@@ -1,0 +1,4288 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<Benchmark xmlns="http://checklists.nist.gov/xccdf/1.1" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="U_CAN_Ubuntu_18-04_STIG" xsi:schemaLocation="http://checklists.nist.gov/xccdf/1.1 http://nvd.nist.gov/schema/xccdf-1.1.4.xsd http://cpe.mitre.org/dictionary/2.0 http://cpe.mitre.org/files/cpe-dictionary_2.1.xsd" xml:lang="en"><status date="2020-12-09">accepted</status><title>Canonical Ubuntu 18.04 LTS Security Technical Implementation Guide</title><description>This Security Technical Implementation Guide is published as a tool to improve the security of Department of Defense (DoD) information systems. The requirements are derived from the National Institute of Standards and Technology (NIST) 800-53 and related documents. Comments or proposed revisions to this document should be sent via email to the following address: disa.stig_spt@mail.mil.</description><notice id="terms-of-use" xml:lang="en" /><front-matter xml:lang="en" /><rear-matter xml:lang="en" /><reference href="https://cyber.mil"><dc:publisher>DISA</dc:publisher><dc:source>STIG.DOD.MIL</dc:source></reference><plain-text id="release-info">Release: 2 Benchmark Date: 22 Jan 2021</plain-text><plain-text id="generator">3.2.1.41666</plain-text><plain-text id="conventionsVersion">1.10.0</plain-text><version>2</version><Profile id="MAC-1_Classified"><title>I - Mission Critical Classified</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-219147" selected="true" /><select idref="V-219148" selected="true" /><select idref="V-219149" selected="true" /><select idref="V-219150" selected="true" /><select idref="V-219151" selected="true" /><select idref="V-219152" selected="true" /><select idref="V-219153" selected="true" /><select idref="V-219154" selected="true" /><select idref="V-219155" selected="true" /><select idref="V-219156" selected="true" /><select idref="V-219157" selected="true" /><select idref="V-219158" selected="true" /><select idref="V-219159" selected="true" /><select idref="V-219160" selected="true" /><select idref="V-219161" selected="true" /><select idref="V-219162" selected="true" /><select idref="V-219163" selected="true" /><select idref="V-219164" selected="true" /><select idref="V-219165" selected="true" /><select idref="V-219166" selected="true" /><select idref="V-219167" selected="true" /><select idref="V-219168" selected="true" /><select idref="V-219169" selected="true" /><select idref="V-219170" selected="true" /><select idref="V-219172" selected="true" /><select idref="V-219173" selected="true" /><select idref="V-219174" selected="true" /><select idref="V-219175" selected="true" /><select idref="V-219176" selected="true" /><select idref="V-219177" selected="true" /><select idref="V-219178" selected="true" /><select idref="V-219179" selected="true" /><select idref="V-219180" selected="true" /><select idref="V-219181" selected="true" /><select idref="V-219182" selected="true" /><select idref="V-219183" selected="true" /><select idref="V-219184" selected="true" /><select idref="V-219185" selected="true" /><select idref="V-219186" selected="true" /><select idref="V-219187" selected="true" /><select idref="V-219188" selected="true" /><select idref="V-219189" selected="true" /><select idref="V-219190" selected="true" /><select idref="V-219191" selected="true" /><select idref="V-219192" selected="true" /><select idref="V-219193" selected="true" /><select idref="V-219194" selected="true" /><select idref="V-219195" selected="true" /><select idref="V-219196" selected="true" /><select idref="V-219197" selected="true" /><select idref="V-219198" selected="true" /><select idref="V-219199" selected="true" /><select idref="V-219200" selected="true" /><select idref="V-219201" selected="true" /><select idref="V-219202" selected="true" /><select idref="V-219203" selected="true" /><select idref="V-219204" selected="true" /><select idref="V-219205" selected="true" /><select idref="V-219206" selected="true" /><select idref="V-219207" selected="true" /><select idref="V-219208" selected="true" /><select idref="V-219209" selected="true" /><select idref="V-219210" selected="true" /><select idref="V-219211" selected="true" /><select idref="V-219212" selected="true" /><select idref="V-219213" selected="true" /><select idref="V-219214" selected="true" /><select idref="V-219215" selected="true" /><select idref="V-219216" selected="true" /><select idref="V-219217" selected="true" /><select idref="V-219218" selected="true" /><select idref="V-219219" selected="true" /><select idref="V-219220" selected="true" /><select idref="V-219221" selected="true" /><select idref="V-219222" selected="true" /><select idref="V-219223" selected="true" /><select idref="V-219224" selected="true" /><select idref="V-219225" selected="true" /><select idref="V-219226" selected="true" /><select idref="V-219227" selected="true" /><select idref="V-219228" selected="true" /><select idref="V-219229" selected="true" /><select idref="V-219230" selected="true" /><select idref="V-219231" selected="true" /><select idref="V-219232" selected="true" /><select idref="V-219233" selected="true" /><select idref="V-219234" selected="true" /><select idref="V-219235" selected="true" /><select idref="V-219236" selected="true" /><select idref="V-219237" selected="true" /><select idref="V-219238" selected="true" /><select idref="V-219239" selected="true" /><select idref="V-219240" selected="true" /><select idref="V-219241" selected="true" /><select idref="V-219242" selected="true" /><select idref="V-219243" selected="true" /><select idref="V-219244" selected="true" /><select idref="V-219245" selected="true" /><select idref="V-219246" selected="true" /><select idref="V-219247" selected="true" /><select idref="V-219248" selected="true" /><select idref="V-219249" selected="true" /><select idref="V-219250" selected="true" /><select idref="V-219251" selected="true" /><select idref="V-219252" selected="true" /><select idref="V-219253" selected="true" /><select idref="V-219254" selected="true" /><select idref="V-219255" selected="true" /><select idref="V-219256" selected="true" /><select idref="V-219257" selected="true" /><select idref="V-219261" selected="true" /><select idref="V-219262" selected="true" /><select idref="V-219263" selected="true" /><select idref="V-219264" selected="true" /><select idref="V-219265" selected="true" /><select idref="V-219266" selected="true" /><select idref="V-219267" selected="true" /><select idref="V-219268" selected="true" /><select idref="V-219269" selected="true" /><select idref="V-219270" selected="true" /><select idref="V-219271" selected="true" /><select idref="V-219272" selected="true" /><select idref="V-219273" selected="true" /><select idref="V-219274" selected="true" /><select idref="V-219275" selected="true" /><select idref="V-219276" selected="true" /><select idref="V-219277" selected="true" /><select idref="V-219278" selected="true" /><select idref="V-219279" selected="true" /><select idref="V-219280" selected="true" /><select idref="V-219281" selected="true" /><select idref="V-219282" selected="true" /><select idref="V-219283" selected="true" /><select idref="V-219284" selected="true" /><select idref="V-219285" selected="true" /><select idref="V-219286" selected="true" /><select idref="V-219287" selected="true" /><select idref="V-219288" selected="true" /><select idref="V-219289" selected="true" /><select idref="V-219290" selected="true" /><select idref="V-219291" selected="true" /><select idref="V-219292" selected="true" /><select idref="V-219293" selected="true" /><select idref="V-219294" selected="true" /><select idref="V-219295" selected="true" /><select idref="V-219296" selected="true" /><select idref="V-219297" selected="true" /><select idref="V-219298" selected="true" /><select idref="V-219299" selected="true" /><select idref="V-219300" selected="true" /><select idref="V-219301" selected="true" /><select idref="V-219302" selected="true" /><select idref="V-219303" selected="true" /><select idref="V-219304" selected="true" /><select idref="V-219306" selected="true" /><select idref="V-219307" selected="true" /><select idref="V-219308" selected="true" /><select idref="V-219309" selected="true" /><select idref="V-219310" selected="true" /><select idref="V-219311" selected="true" /><select idref="V-219312" selected="true" /><select idref="V-219313" selected="true" /><select idref="V-219314" selected="true" /><select idref="V-219315" selected="true" /><select idref="V-219316" selected="true" /><select idref="V-219317" selected="true" /><select idref="V-219318" selected="true" /><select idref="V-219319" selected="true" /><select idref="V-219320" selected="true" /><select idref="V-219321" selected="true" /><select idref="V-219322" selected="true" /><select idref="V-219323" selected="true" /><select idref="V-219324" selected="true" /><select idref="V-219325" selected="true" /><select idref="V-219326" selected="true" /><select idref="V-219327" selected="true" /><select idref="V-219328" selected="true" /><select idref="V-219329" selected="true" /><select idref="V-219330" selected="true" /><select idref="V-219331" selected="true" /><select idref="V-219332" selected="true" /><select idref="V-219333" selected="true" /><select idref="V-219334" selected="true" /><select idref="V-219335" selected="true" /><select idref="V-219336" selected="true" /><select idref="V-219337" selected="true" /><select idref="V-219338" selected="true" /><select idref="V-219339" selected="true" /><select idref="V-219340" selected="true" /><select idref="V-219341" selected="true" /><select idref="V-219342" selected="true" /><select idref="V-219343" selected="true" /><select idref="V-219344" selected="true" /><select idref="V-219346" selected="true" /><select idref="V-233779" selected="true" /><select idref="V-233780" selected="true" /></Profile><Profile id="MAC-1_Public"><title>I - Mission Critical Public</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-219147" selected="true" /><select idref="V-219148" selected="true" /><select idref="V-219149" selected="true" /><select idref="V-219150" selected="true" /><select idref="V-219151" selected="true" /><select idref="V-219152" selected="true" /><select idref="V-219153" selected="true" /><select idref="V-219154" selected="true" /><select idref="V-219155" selected="true" /><select idref="V-219156" selected="true" /><select idref="V-219157" selected="true" /><select idref="V-219158" selected="true" /><select idref="V-219159" selected="true" /><select idref="V-219160" selected="true" /><select idref="V-219161" selected="true" /><select idref="V-219162" selected="true" /><select idref="V-219163" selected="true" /><select idref="V-219164" selected="true" /><select idref="V-219165" selected="true" /><select idref="V-219166" selected="true" /><select idref="V-219167" selected="true" /><select idref="V-219168" selected="true" /><select idref="V-219169" selected="true" /><select idref="V-219170" selected="true" /><select idref="V-219172" selected="true" /><select idref="V-219173" selected="true" /><select idref="V-219174" selected="true" /><select idref="V-219175" selected="true" /><select idref="V-219176" selected="true" /><select idref="V-219177" selected="true" /><select idref="V-219178" selected="true" /><select idref="V-219179" selected="true" /><select idref="V-219180" selected="true" /><select idref="V-219181" selected="true" /><select idref="V-219182" selected="true" /><select idref="V-219183" selected="true" /><select idref="V-219184" selected="true" /><select idref="V-219185" selected="true" /><select idref="V-219186" selected="true" /><select idref="V-219187" selected="true" /><select idref="V-219188" selected="true" /><select idref="V-219189" selected="true" /><select idref="V-219190" selected="true" /><select idref="V-219191" selected="true" /><select idref="V-219192" selected="true" /><select idref="V-219193" selected="true" /><select idref="V-219194" selected="true" /><select idref="V-219195" selected="true" /><select idref="V-219196" selected="true" /><select idref="V-219197" selected="true" /><select idref="V-219198" selected="true" /><select idref="V-219199" selected="true" /><select idref="V-219200" selected="true" /><select idref="V-219201" selected="true" /><select idref="V-219202" selected="true" /><select idref="V-219203" selected="true" /><select idref="V-219204" selected="true" /><select idref="V-219205" selected="true" /><select idref="V-219206" selected="true" /><select idref="V-219207" selected="true" /><select idref="V-219208" selected="true" /><select idref="V-219209" selected="true" /><select idref="V-219210" selected="true" /><select idref="V-219211" selected="true" /><select idref="V-219212" selected="true" /><select idref="V-219213" selected="true" /><select idref="V-219214" selected="true" /><select idref="V-219215" selected="true" /><select idref="V-219216" selected="true" /><select idref="V-219217" selected="true" /><select idref="V-219218" selected="true" /><select idref="V-219219" selected="true" /><select idref="V-219220" selected="true" /><select idref="V-219221" selected="true" /><select idref="V-219222" selected="true" /><select idref="V-219223" selected="true" /><select idref="V-219224" selected="true" /><select idref="V-219225" selected="true" /><select idref="V-219226" selected="true" /><select idref="V-219227" selected="true" /><select idref="V-219228" selected="true" /><select idref="V-219229" selected="true" /><select idref="V-219230" selected="true" /><select idref="V-219231" selected="true" /><select idref="V-219232" selected="true" /><select idref="V-219233" selected="true" /><select idref="V-219234" selected="true" /><select idref="V-219235" selected="true" /><select idref="V-219236" selected="true" /><select idref="V-219237" selected="true" /><select idref="V-219238" selected="true" /><select idref="V-219239" selected="true" /><select idref="V-219240" selected="true" /><select idref="V-219241" selected="true" /><select idref="V-219242" selected="true" /><select idref="V-219243" selected="true" /><select idref="V-219244" selected="true" /><select idref="V-219245" selected="true" /><select idref="V-219246" selected="true" /><select idref="V-219247" selected="true" /><select idref="V-219248" selected="true" /><select idref="V-219249" selected="true" /><select idref="V-219250" selected="true" /><select idref="V-219251" selected="true" /><select idref="V-219252" selected="true" /><select idref="V-219253" selected="true" /><select idref="V-219254" selected="true" /><select idref="V-219255" selected="true" /><select idref="V-219256" selected="true" /><select idref="V-219257" selected="true" /><select idref="V-219261" selected="true" /><select idref="V-219262" selected="true" /><select idref="V-219263" selected="true" /><select idref="V-219264" selected="true" /><select idref="V-219265" selected="true" /><select idref="V-219266" selected="true" /><select idref="V-219267" selected="true" /><select idref="V-219268" selected="true" /><select idref="V-219269" selected="true" /><select idref="V-219270" selected="true" /><select idref="V-219271" selected="true" /><select idref="V-219272" selected="true" /><select idref="V-219273" selected="true" /><select idref="V-219274" selected="true" /><select idref="V-219275" selected="true" /><select idref="V-219276" selected="true" /><select idref="V-219277" selected="true" /><select idref="V-219278" selected="true" /><select idref="V-219279" selected="true" /><select idref="V-219280" selected="true" /><select idref="V-219281" selected="true" /><select idref="V-219282" selected="true" /><select idref="V-219283" selected="true" /><select idref="V-219284" selected="true" /><select idref="V-219285" selected="true" /><select idref="V-219286" selected="true" /><select idref="V-219287" selected="true" /><select idref="V-219288" selected="true" /><select idref="V-219289" selected="true" /><select idref="V-219290" selected="true" /><select idref="V-219291" selected="true" /><select idref="V-219292" selected="true" /><select idref="V-219293" selected="true" /><select idref="V-219294" selected="true" /><select idref="V-219295" selected="true" /><select idref="V-219296" selected="true" /><select idref="V-219297" selected="true" /><select idref="V-219298" selected="true" /><select idref="V-219299" selected="true" /><select idref="V-219300" selected="true" /><select idref="V-219301" selected="true" /><select idref="V-219302" selected="true" /><select idref="V-219303" selected="true" /><select idref="V-219304" selected="true" /><select idref="V-219306" selected="true" /><select idref="V-219307" selected="true" /><select idref="V-219308" selected="true" /><select idref="V-219309" selected="true" /><select idref="V-219310" selected="true" /><select idref="V-219311" selected="true" /><select idref="V-219312" selected="true" /><select idref="V-219313" selected="true" /><select idref="V-219314" selected="true" /><select idref="V-219315" selected="true" /><select idref="V-219316" selected="true" /><select idref="V-219317" selected="true" /><select idref="V-219318" selected="true" /><select idref="V-219319" selected="true" /><select idref="V-219320" selected="true" /><select idref="V-219321" selected="true" /><select idref="V-219322" selected="true" /><select idref="V-219323" selected="true" /><select idref="V-219324" selected="true" /><select idref="V-219325" selected="true" /><select idref="V-219326" selected="true" /><select idref="V-219327" selected="true" /><select idref="V-219328" selected="true" /><select idref="V-219329" selected="true" /><select idref="V-219330" selected="true" /><select idref="V-219331" selected="true" /><select idref="V-219332" selected="true" /><select idref="V-219333" selected="true" /><select idref="V-219334" selected="true" /><select idref="V-219335" selected="true" /><select idref="V-219336" selected="true" /><select idref="V-219337" selected="true" /><select idref="V-219338" selected="true" /><select idref="V-219339" selected="true" /><select idref="V-219340" selected="true" /><select idref="V-219341" selected="true" /><select idref="V-219342" selected="true" /><select idref="V-219343" selected="true" /><select idref="V-219344" selected="true" /><select idref="V-219346" selected="true" /><select idref="V-233779" selected="true" /><select idref="V-233780" selected="true" /></Profile><Profile id="MAC-1_Sensitive"><title>I - Mission Critical Sensitive</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-219147" selected="true" /><select idref="V-219148" selected="true" /><select idref="V-219149" selected="true" /><select idref="V-219150" selected="true" /><select idref="V-219151" selected="true" /><select idref="V-219152" selected="true" /><select idref="V-219153" selected="true" /><select idref="V-219154" selected="true" /><select idref="V-219155" selected="true" /><select idref="V-219156" selected="true" /><select idref="V-219157" selected="true" /><select idref="V-219158" selected="true" /><select idref="V-219159" selected="true" /><select idref="V-219160" selected="true" /><select idref="V-219161" selected="true" /><select idref="V-219162" selected="true" /><select idref="V-219163" selected="true" /><select idref="V-219164" selected="true" /><select idref="V-219165" selected="true" /><select idref="V-219166" selected="true" /><select idref="V-219167" selected="true" /><select idref="V-219168" selected="true" /><select idref="V-219169" selected="true" /><select idref="V-219170" selected="true" /><select idref="V-219172" selected="true" /><select idref="V-219173" selected="true" /><select idref="V-219174" selected="true" /><select idref="V-219175" selected="true" /><select idref="V-219176" selected="true" /><select idref="V-219177" selected="true" /><select idref="V-219178" selected="true" /><select idref="V-219179" selected="true" /><select idref="V-219180" selected="true" /><select idref="V-219181" selected="true" /><select idref="V-219182" selected="true" /><select idref="V-219183" selected="true" /><select idref="V-219184" selected="true" /><select idref="V-219185" selected="true" /><select idref="V-219186" selected="true" /><select idref="V-219187" selected="true" /><select idref="V-219188" selected="true" /><select idref="V-219189" selected="true" /><select idref="V-219190" selected="true" /><select idref="V-219191" selected="true" /><select idref="V-219192" selected="true" /><select idref="V-219193" selected="true" /><select idref="V-219194" selected="true" /><select idref="V-219195" selected="true" /><select idref="V-219196" selected="true" /><select idref="V-219197" selected="true" /><select idref="V-219198" selected="true" /><select idref="V-219199" selected="true" /><select idref="V-219200" selected="true" /><select idref="V-219201" selected="true" /><select idref="V-219202" selected="true" /><select idref="V-219203" selected="true" /><select idref="V-219204" selected="true" /><select idref="V-219205" selected="true" /><select idref="V-219206" selected="true" /><select idref="V-219207" selected="true" /><select idref="V-219208" selected="true" /><select idref="V-219209" selected="true" /><select idref="V-219210" selected="true" /><select idref="V-219211" selected="true" /><select idref="V-219212" selected="true" /><select idref="V-219213" selected="true" /><select idref="V-219214" selected="true" /><select idref="V-219215" selected="true" /><select idref="V-219216" selected="true" /><select idref="V-219217" selected="true" /><select idref="V-219218" selected="true" /><select idref="V-219219" selected="true" /><select idref="V-219220" selected="true" /><select idref="V-219221" selected="true" /><select idref="V-219222" selected="true" /><select idref="V-219223" selected="true" /><select idref="V-219224" selected="true" /><select idref="V-219225" selected="true" /><select idref="V-219226" selected="true" /><select idref="V-219227" selected="true" /><select idref="V-219228" selected="true" /><select idref="V-219229" selected="true" /><select idref="V-219230" selected="true" /><select idref="V-219231" selected="true" /><select idref="V-219232" selected="true" /><select idref="V-219233" selected="true" /><select idref="V-219234" selected="true" /><select idref="V-219235" selected="true" /><select idref="V-219236" selected="true" /><select idref="V-219237" selected="true" /><select idref="V-219238" selected="true" /><select idref="V-219239" selected="true" /><select idref="V-219240" selected="true" /><select idref="V-219241" selected="true" /><select idref="V-219242" selected="true" /><select idref="V-219243" selected="true" /><select idref="V-219244" selected="true" /><select idref="V-219245" selected="true" /><select idref="V-219246" selected="true" /><select idref="V-219247" selected="true" /><select idref="V-219248" selected="true" /><select idref="V-219249" selected="true" /><select idref="V-219250" selected="true" /><select idref="V-219251" selected="true" /><select idref="V-219252" selected="true" /><select idref="V-219253" selected="true" /><select idref="V-219254" selected="true" /><select idref="V-219255" selected="true" /><select idref="V-219256" selected="true" /><select idref="V-219257" selected="true" /><select idref="V-219261" selected="true" /><select idref="V-219262" selected="true" /><select idref="V-219263" selected="true" /><select idref="V-219264" selected="true" /><select idref="V-219265" selected="true" /><select idref="V-219266" selected="true" /><select idref="V-219267" selected="true" /><select idref="V-219268" selected="true" /><select idref="V-219269" selected="true" /><select idref="V-219270" selected="true" /><select idref="V-219271" selected="true" /><select idref="V-219272" selected="true" /><select idref="V-219273" selected="true" /><select idref="V-219274" selected="true" /><select idref="V-219275" selected="true" /><select idref="V-219276" selected="true" /><select idref="V-219277" selected="true" /><select idref="V-219278" selected="true" /><select idref="V-219279" selected="true" /><select idref="V-219280" selected="true" /><select idref="V-219281" selected="true" /><select idref="V-219282" selected="true" /><select idref="V-219283" selected="true" /><select idref="V-219284" selected="true" /><select idref="V-219285" selected="true" /><select idref="V-219286" selected="true" /><select idref="V-219287" selected="true" /><select idref="V-219288" selected="true" /><select idref="V-219289" selected="true" /><select idref="V-219290" selected="true" /><select idref="V-219291" selected="true" /><select idref="V-219292" selected="true" /><select idref="V-219293" selected="true" /><select idref="V-219294" selected="true" /><select idref="V-219295" selected="true" /><select idref="V-219296" selected="true" /><select idref="V-219297" selected="true" /><select idref="V-219298" selected="true" /><select idref="V-219299" selected="true" /><select idref="V-219300" selected="true" /><select idref="V-219301" selected="true" /><select idref="V-219302" selected="true" /><select idref="V-219303" selected="true" /><select idref="V-219304" selected="true" /><select idref="V-219306" selected="true" /><select idref="V-219307" selected="true" /><select idref="V-219308" selected="true" /><select idref="V-219309" selected="true" /><select idref="V-219310" selected="true" /><select idref="V-219311" selected="true" /><select idref="V-219312" selected="true" /><select idref="V-219313" selected="true" /><select idref="V-219314" selected="true" /><select idref="V-219315" selected="true" /><select idref="V-219316" selected="true" /><select idref="V-219317" selected="true" /><select idref="V-219318" selected="true" /><select idref="V-219319" selected="true" /><select idref="V-219320" selected="true" /><select idref="V-219321" selected="true" /><select idref="V-219322" selected="true" /><select idref="V-219323" selected="true" /><select idref="V-219324" selected="true" /><select idref="V-219325" selected="true" /><select idref="V-219326" selected="true" /><select idref="V-219327" selected="true" /><select idref="V-219328" selected="true" /><select idref="V-219329" selected="true" /><select idref="V-219330" selected="true" /><select idref="V-219331" selected="true" /><select idref="V-219332" selected="true" /><select idref="V-219333" selected="true" /><select idref="V-219334" selected="true" /><select idref="V-219335" selected="true" /><select idref="V-219336" selected="true" /><select idref="V-219337" selected="true" /><select idref="V-219338" selected="true" /><select idref="V-219339" selected="true" /><select idref="V-219340" selected="true" /><select idref="V-219341" selected="true" /><select idref="V-219342" selected="true" /><select idref="V-219343" selected="true" /><select idref="V-219344" selected="true" /><select idref="V-219346" selected="true" /><select idref="V-233779" selected="true" /><select idref="V-233780" selected="true" /></Profile><Profile id="MAC-2_Classified"><title>II - Mission Support Classified</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-219147" selected="true" /><select idref="V-219148" selected="true" /><select idref="V-219149" selected="true" /><select idref="V-219150" selected="true" /><select idref="V-219151" selected="true" /><select idref="V-219152" selected="true" /><select idref="V-219153" selected="true" /><select idref="V-219154" selected="true" /><select idref="V-219155" selected="true" /><select idref="V-219156" selected="true" /><select idref="V-219157" selected="true" /><select idref="V-219158" selected="true" /><select idref="V-219159" selected="true" /><select idref="V-219160" selected="true" /><select idref="V-219161" selected="true" /><select idref="V-219162" selected="true" /><select idref="V-219163" selected="true" /><select idref="V-219164" selected="true" /><select idref="V-219165" selected="true" /><select idref="V-219166" selected="true" /><select idref="V-219167" selected="true" /><select idref="V-219168" selected="true" /><select idref="V-219169" selected="true" /><select idref="V-219170" selected="true" /><select idref="V-219172" selected="true" /><select idref="V-219173" selected="true" /><select idref="V-219174" selected="true" /><select idref="V-219175" selected="true" /><select idref="V-219176" selected="true" /><select idref="V-219177" selected="true" /><select idref="V-219178" selected="true" /><select idref="V-219179" selected="true" /><select idref="V-219180" selected="true" /><select idref="V-219181" selected="true" /><select idref="V-219182" selected="true" /><select idref="V-219183" selected="true" /><select idref="V-219184" selected="true" /><select idref="V-219185" selected="true" /><select idref="V-219186" selected="true" /><select idref="V-219187" selected="true" /><select idref="V-219188" selected="true" /><select idref="V-219189" selected="true" /><select idref="V-219190" selected="true" /><select idref="V-219191" selected="true" /><select idref="V-219192" selected="true" /><select idref="V-219193" selected="true" /><select idref="V-219194" selected="true" /><select idref="V-219195" selected="true" /><select idref="V-219196" selected="true" /><select idref="V-219197" selected="true" /><select idref="V-219198" selected="true" /><select idref="V-219199" selected="true" /><select idref="V-219200" selected="true" /><select idref="V-219201" selected="true" /><select idref="V-219202" selected="true" /><select idref="V-219203" selected="true" /><select idref="V-219204" selected="true" /><select idref="V-219205" selected="true" /><select idref="V-219206" selected="true" /><select idref="V-219207" selected="true" /><select idref="V-219208" selected="true" /><select idref="V-219209" selected="true" /><select idref="V-219210" selected="true" /><select idref="V-219211" selected="true" /><select idref="V-219212" selected="true" /><select idref="V-219213" selected="true" /><select idref="V-219214" selected="true" /><select idref="V-219215" selected="true" /><select idref="V-219216" selected="true" /><select idref="V-219217" selected="true" /><select idref="V-219218" selected="true" /><select idref="V-219219" selected="true" /><select idref="V-219220" selected="true" /><select idref="V-219221" selected="true" /><select idref="V-219222" selected="true" /><select idref="V-219223" selected="true" /><select idref="V-219224" selected="true" /><select idref="V-219225" selected="true" /><select idref="V-219226" selected="true" /><select idref="V-219227" selected="true" /><select idref="V-219228" selected="true" /><select idref="V-219229" selected="true" /><select idref="V-219230" selected="true" /><select idref="V-219231" selected="true" /><select idref="V-219232" selected="true" /><select idref="V-219233" selected="true" /><select idref="V-219234" selected="true" /><select idref="V-219235" selected="true" /><select idref="V-219236" selected="true" /><select idref="V-219237" selected="true" /><select idref="V-219238" selected="true" /><select idref="V-219239" selected="true" /><select idref="V-219240" selected="true" /><select idref="V-219241" selected="true" /><select idref="V-219242" selected="true" /><select idref="V-219243" selected="true" /><select idref="V-219244" selected="true" /><select idref="V-219245" selected="true" /><select idref="V-219246" selected="true" /><select idref="V-219247" selected="true" /><select idref="V-219248" selected="true" /><select idref="V-219249" selected="true" /><select idref="V-219250" selected="true" /><select idref="V-219251" selected="true" /><select idref="V-219252" selected="true" /><select idref="V-219253" selected="true" /><select idref="V-219254" selected="true" /><select idref="V-219255" selected="true" /><select idref="V-219256" selected="true" /><select idref="V-219257" selected="true" /><select idref="V-219261" selected="true" /><select idref="V-219262" selected="true" /><select idref="V-219263" selected="true" /><select idref="V-219264" selected="true" /><select idref="V-219265" selected="true" /><select idref="V-219266" selected="true" /><select idref="V-219267" selected="true" /><select idref="V-219268" selected="true" /><select idref="V-219269" selected="true" /><select idref="V-219270" selected="true" /><select idref="V-219271" selected="true" /><select idref="V-219272" selected="true" /><select idref="V-219273" selected="true" /><select idref="V-219274" selected="true" /><select idref="V-219275" selected="true" /><select idref="V-219276" selected="true" /><select idref="V-219277" selected="true" /><select idref="V-219278" selected="true" /><select idref="V-219279" selected="true" /><select idref="V-219280" selected="true" /><select idref="V-219281" selected="true" /><select idref="V-219282" selected="true" /><select idref="V-219283" selected="true" /><select idref="V-219284" selected="true" /><select idref="V-219285" selected="true" /><select idref="V-219286" selected="true" /><select idref="V-219287" selected="true" /><select idref="V-219288" selected="true" /><select idref="V-219289" selected="true" /><select idref="V-219290" selected="true" /><select idref="V-219291" selected="true" /><select idref="V-219292" selected="true" /><select idref="V-219293" selected="true" /><select idref="V-219294" selected="true" /><select idref="V-219295" selected="true" /><select idref="V-219296" selected="true" /><select idref="V-219297" selected="true" /><select idref="V-219298" selected="true" /><select idref="V-219299" selected="true" /><select idref="V-219300" selected="true" /><select idref="V-219301" selected="true" /><select idref="V-219302" selected="true" /><select idref="V-219303" selected="true" /><select idref="V-219304" selected="true" /><select idref="V-219306" selected="true" /><select idref="V-219307" selected="true" /><select idref="V-219308" selected="true" /><select idref="V-219309" selected="true" /><select idref="V-219310" selected="true" /><select idref="V-219311" selected="true" /><select idref="V-219312" selected="true" /><select idref="V-219313" selected="true" /><select idref="V-219314" selected="true" /><select idref="V-219315" selected="true" /><select idref="V-219316" selected="true" /><select idref="V-219317" selected="true" /><select idref="V-219318" selected="true" /><select idref="V-219319" selected="true" /><select idref="V-219320" selected="true" /><select idref="V-219321" selected="true" /><select idref="V-219322" selected="true" /><select idref="V-219323" selected="true" /><select idref="V-219324" selected="true" /><select idref="V-219325" selected="true" /><select idref="V-219326" selected="true" /><select idref="V-219327" selected="true" /><select idref="V-219328" selected="true" /><select idref="V-219329" selected="true" /><select idref="V-219330" selected="true" /><select idref="V-219331" selected="true" /><select idref="V-219332" selected="true" /><select idref="V-219333" selected="true" /><select idref="V-219334" selected="true" /><select idref="V-219335" selected="true" /><select idref="V-219336" selected="true" /><select idref="V-219337" selected="true" /><select idref="V-219338" selected="true" /><select idref="V-219339" selected="true" /><select idref="V-219340" selected="true" /><select idref="V-219341" selected="true" /><select idref="V-219342" selected="true" /><select idref="V-219343" selected="true" /><select idref="V-219344" selected="true" /><select idref="V-219346" selected="true" /><select idref="V-233779" selected="true" /><select idref="V-233780" selected="true" /></Profile><Profile id="MAC-2_Public"><title>II - Mission Support Public</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-219147" selected="true" /><select idref="V-219148" selected="true" /><select idref="V-219149" selected="true" /><select idref="V-219150" selected="true" /><select idref="V-219151" selected="true" /><select idref="V-219152" selected="true" /><select idref="V-219153" selected="true" /><select idref="V-219154" selected="true" /><select idref="V-219155" selected="true" /><select idref="V-219156" selected="true" /><select idref="V-219157" selected="true" /><select idref="V-219158" selected="true" /><select idref="V-219159" selected="true" /><select idref="V-219160" selected="true" /><select idref="V-219161" selected="true" /><select idref="V-219162" selected="true" /><select idref="V-219163" selected="true" /><select idref="V-219164" selected="true" /><select idref="V-219165" selected="true" /><select idref="V-219166" selected="true" /><select idref="V-219167" selected="true" /><select idref="V-219168" selected="true" /><select idref="V-219169" selected="true" /><select idref="V-219170" selected="true" /><select idref="V-219172" selected="true" /><select idref="V-219173" selected="true" /><select idref="V-219174" selected="true" /><select idref="V-219175" selected="true" /><select idref="V-219176" selected="true" /><select idref="V-219177" selected="true" /><select idref="V-219178" selected="true" /><select idref="V-219179" selected="true" /><select idref="V-219180" selected="true" /><select idref="V-219181" selected="true" /><select idref="V-219182" selected="true" /><select idref="V-219183" selected="true" /><select idref="V-219184" selected="true" /><select idref="V-219185" selected="true" /><select idref="V-219186" selected="true" /><select idref="V-219187" selected="true" /><select idref="V-219188" selected="true" /><select idref="V-219189" selected="true" /><select idref="V-219190" selected="true" /><select idref="V-219191" selected="true" /><select idref="V-219192" selected="true" /><select idref="V-219193" selected="true" /><select idref="V-219194" selected="true" /><select idref="V-219195" selected="true" /><select idref="V-219196" selected="true" /><select idref="V-219197" selected="true" /><select idref="V-219198" selected="true" /><select idref="V-219199" selected="true" /><select idref="V-219200" selected="true" /><select idref="V-219201" selected="true" /><select idref="V-219202" selected="true" /><select idref="V-219203" selected="true" /><select idref="V-219204" selected="true" /><select idref="V-219205" selected="true" /><select idref="V-219206" selected="true" /><select idref="V-219207" selected="true" /><select idref="V-219208" selected="true" /><select idref="V-219209" selected="true" /><select idref="V-219210" selected="true" /><select idref="V-219211" selected="true" /><select idref="V-219212" selected="true" /><select idref="V-219213" selected="true" /><select idref="V-219214" selected="true" /><select idref="V-219215" selected="true" /><select idref="V-219216" selected="true" /><select idref="V-219217" selected="true" /><select idref="V-219218" selected="true" /><select idref="V-219219" selected="true" /><select idref="V-219220" selected="true" /><select idref="V-219221" selected="true" /><select idref="V-219222" selected="true" /><select idref="V-219223" selected="true" /><select idref="V-219224" selected="true" /><select idref="V-219225" selected="true" /><select idref="V-219226" selected="true" /><select idref="V-219227" selected="true" /><select idref="V-219228" selected="true" /><select idref="V-219229" selected="true" /><select idref="V-219230" selected="true" /><select idref="V-219231" selected="true" /><select idref="V-219232" selected="true" /><select idref="V-219233" selected="true" /><select idref="V-219234" selected="true" /><select idref="V-219235" selected="true" /><select idref="V-219236" selected="true" /><select idref="V-219237" selected="true" /><select idref="V-219238" selected="true" /><select idref="V-219239" selected="true" /><select idref="V-219240" selected="true" /><select idref="V-219241" selected="true" /><select idref="V-219242" selected="true" /><select idref="V-219243" selected="true" /><select idref="V-219244" selected="true" /><select idref="V-219245" selected="true" /><select idref="V-219246" selected="true" /><select idref="V-219247" selected="true" /><select idref="V-219248" selected="true" /><select idref="V-219249" selected="true" /><select idref="V-219250" selected="true" /><select idref="V-219251" selected="true" /><select idref="V-219252" selected="true" /><select idref="V-219253" selected="true" /><select idref="V-219254" selected="true" /><select idref="V-219255" selected="true" /><select idref="V-219256" selected="true" /><select idref="V-219257" selected="true" /><select idref="V-219261" selected="true" /><select idref="V-219262" selected="true" /><select idref="V-219263" selected="true" /><select idref="V-219264" selected="true" /><select idref="V-219265" selected="true" /><select idref="V-219266" selected="true" /><select idref="V-219267" selected="true" /><select idref="V-219268" selected="true" /><select idref="V-219269" selected="true" /><select idref="V-219270" selected="true" /><select idref="V-219271" selected="true" /><select idref="V-219272" selected="true" /><select idref="V-219273" selected="true" /><select idref="V-219274" selected="true" /><select idref="V-219275" selected="true" /><select idref="V-219276" selected="true" /><select idref="V-219277" selected="true" /><select idref="V-219278" selected="true" /><select idref="V-219279" selected="true" /><select idref="V-219280" selected="true" /><select idref="V-219281" selected="true" /><select idref="V-219282" selected="true" /><select idref="V-219283" selected="true" /><select idref="V-219284" selected="true" /><select idref="V-219285" selected="true" /><select idref="V-219286" selected="true" /><select idref="V-219287" selected="true" /><select idref="V-219288" selected="true" /><select idref="V-219289" selected="true" /><select idref="V-219290" selected="true" /><select idref="V-219291" selected="true" /><select idref="V-219292" selected="true" /><select idref="V-219293" selected="true" /><select idref="V-219294" selected="true" /><select idref="V-219295" selected="true" /><select idref="V-219296" selected="true" /><select idref="V-219297" selected="true" /><select idref="V-219298" selected="true" /><select idref="V-219299" selected="true" /><select idref="V-219300" selected="true" /><select idref="V-219301" selected="true" /><select idref="V-219302" selected="true" /><select idref="V-219303" selected="true" /><select idref="V-219304" selected="true" /><select idref="V-219306" selected="true" /><select idref="V-219307" selected="true" /><select idref="V-219308" selected="true" /><select idref="V-219309" selected="true" /><select idref="V-219310" selected="true" /><select idref="V-219311" selected="true" /><select idref="V-219312" selected="true" /><select idref="V-219313" selected="true" /><select idref="V-219314" selected="true" /><select idref="V-219315" selected="true" /><select idref="V-219316" selected="true" /><select idref="V-219317" selected="true" /><select idref="V-219318" selected="true" /><select idref="V-219319" selected="true" /><select idref="V-219320" selected="true" /><select idref="V-219321" selected="true" /><select idref="V-219322" selected="true" /><select idref="V-219323" selected="true" /><select idref="V-219324" selected="true" /><select idref="V-219325" selected="true" /><select idref="V-219326" selected="true" /><select idref="V-219327" selected="true" /><select idref="V-219328" selected="true" /><select idref="V-219329" selected="true" /><select idref="V-219330" selected="true" /><select idref="V-219331" selected="true" /><select idref="V-219332" selected="true" /><select idref="V-219333" selected="true" /><select idref="V-219334" selected="true" /><select idref="V-219335" selected="true" /><select idref="V-219336" selected="true" /><select idref="V-219337" selected="true" /><select idref="V-219338" selected="true" /><select idref="V-219339" selected="true" /><select idref="V-219340" selected="true" /><select idref="V-219341" selected="true" /><select idref="V-219342" selected="true" /><select idref="V-219343" selected="true" /><select idref="V-219344" selected="true" /><select idref="V-219346" selected="true" /><select idref="V-233779" selected="true" /><select idref="V-233780" selected="true" /></Profile><Profile id="MAC-2_Sensitive"><title>II - Mission Support Sensitive</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-219147" selected="true" /><select idref="V-219148" selected="true" /><select idref="V-219149" selected="true" /><select idref="V-219150" selected="true" /><select idref="V-219151" selected="true" /><select idref="V-219152" selected="true" /><select idref="V-219153" selected="true" /><select idref="V-219154" selected="true" /><select idref="V-219155" selected="true" /><select idref="V-219156" selected="true" /><select idref="V-219157" selected="true" /><select idref="V-219158" selected="true" /><select idref="V-219159" selected="true" /><select idref="V-219160" selected="true" /><select idref="V-219161" selected="true" /><select idref="V-219162" selected="true" /><select idref="V-219163" selected="true" /><select idref="V-219164" selected="true" /><select idref="V-219165" selected="true" /><select idref="V-219166" selected="true" /><select idref="V-219167" selected="true" /><select idref="V-219168" selected="true" /><select idref="V-219169" selected="true" /><select idref="V-219170" selected="true" /><select idref="V-219172" selected="true" /><select idref="V-219173" selected="true" /><select idref="V-219174" selected="true" /><select idref="V-219175" selected="true" /><select idref="V-219176" selected="true" /><select idref="V-219177" selected="true" /><select idref="V-219178" selected="true" /><select idref="V-219179" selected="true" /><select idref="V-219180" selected="true" /><select idref="V-219181" selected="true" /><select idref="V-219182" selected="true" /><select idref="V-219183" selected="true" /><select idref="V-219184" selected="true" /><select idref="V-219185" selected="true" /><select idref="V-219186" selected="true" /><select idref="V-219187" selected="true" /><select idref="V-219188" selected="true" /><select idref="V-219189" selected="true" /><select idref="V-219190" selected="true" /><select idref="V-219191" selected="true" /><select idref="V-219192" selected="true" /><select idref="V-219193" selected="true" /><select idref="V-219194" selected="true" /><select idref="V-219195" selected="true" /><select idref="V-219196" selected="true" /><select idref="V-219197" selected="true" /><select idref="V-219198" selected="true" /><select idref="V-219199" selected="true" /><select idref="V-219200" selected="true" /><select idref="V-219201" selected="true" /><select idref="V-219202" selected="true" /><select idref="V-219203" selected="true" /><select idref="V-219204" selected="true" /><select idref="V-219205" selected="true" /><select idref="V-219206" selected="true" /><select idref="V-219207" selected="true" /><select idref="V-219208" selected="true" /><select idref="V-219209" selected="true" /><select idref="V-219210" selected="true" /><select idref="V-219211" selected="true" /><select idref="V-219212" selected="true" /><select idref="V-219213" selected="true" /><select idref="V-219214" selected="true" /><select idref="V-219215" selected="true" /><select idref="V-219216" selected="true" /><select idref="V-219217" selected="true" /><select idref="V-219218" selected="true" /><select idref="V-219219" selected="true" /><select idref="V-219220" selected="true" /><select idref="V-219221" selected="true" /><select idref="V-219222" selected="true" /><select idref="V-219223" selected="true" /><select idref="V-219224" selected="true" /><select idref="V-219225" selected="true" /><select idref="V-219226" selected="true" /><select idref="V-219227" selected="true" /><select idref="V-219228" selected="true" /><select idref="V-219229" selected="true" /><select idref="V-219230" selected="true" /><select idref="V-219231" selected="true" /><select idref="V-219232" selected="true" /><select idref="V-219233" selected="true" /><select idref="V-219234" selected="true" /><select idref="V-219235" selected="true" /><select idref="V-219236" selected="true" /><select idref="V-219237" selected="true" /><select idref="V-219238" selected="true" /><select idref="V-219239" selected="true" /><select idref="V-219240" selected="true" /><select idref="V-219241" selected="true" /><select idref="V-219242" selected="true" /><select idref="V-219243" selected="true" /><select idref="V-219244" selected="true" /><select idref="V-219245" selected="true" /><select idref="V-219246" selected="true" /><select idref="V-219247" selected="true" /><select idref="V-219248" selected="true" /><select idref="V-219249" selected="true" /><select idref="V-219250" selected="true" /><select idref="V-219251" selected="true" /><select idref="V-219252" selected="true" /><select idref="V-219253" selected="true" /><select idref="V-219254" selected="true" /><select idref="V-219255" selected="true" /><select idref="V-219256" selected="true" /><select idref="V-219257" selected="true" /><select idref="V-219261" selected="true" /><select idref="V-219262" selected="true" /><select idref="V-219263" selected="true" /><select idref="V-219264" selected="true" /><select idref="V-219265" selected="true" /><select idref="V-219266" selected="true" /><select idref="V-219267" selected="true" /><select idref="V-219268" selected="true" /><select idref="V-219269" selected="true" /><select idref="V-219270" selected="true" /><select idref="V-219271" selected="true" /><select idref="V-219272" selected="true" /><select idref="V-219273" selected="true" /><select idref="V-219274" selected="true" /><select idref="V-219275" selected="true" /><select idref="V-219276" selected="true" /><select idref="V-219277" selected="true" /><select idref="V-219278" selected="true" /><select idref="V-219279" selected="true" /><select idref="V-219280" selected="true" /><select idref="V-219281" selected="true" /><select idref="V-219282" selected="true" /><select idref="V-219283" selected="true" /><select idref="V-219284" selected="true" /><select idref="V-219285" selected="true" /><select idref="V-219286" selected="true" /><select idref="V-219287" selected="true" /><select idref="V-219288" selected="true" /><select idref="V-219289" selected="true" /><select idref="V-219290" selected="true" /><select idref="V-219291" selected="true" /><select idref="V-219292" selected="true" /><select idref="V-219293" selected="true" /><select idref="V-219294" selected="true" /><select idref="V-219295" selected="true" /><select idref="V-219296" selected="true" /><select idref="V-219297" selected="true" /><select idref="V-219298" selected="true" /><select idref="V-219299" selected="true" /><select idref="V-219300" selected="true" /><select idref="V-219301" selected="true" /><select idref="V-219302" selected="true" /><select idref="V-219303" selected="true" /><select idref="V-219304" selected="true" /><select idref="V-219306" selected="true" /><select idref="V-219307" selected="true" /><select idref="V-219308" selected="true" /><select idref="V-219309" selected="true" /><select idref="V-219310" selected="true" /><select idref="V-219311" selected="true" /><select idref="V-219312" selected="true" /><select idref="V-219313" selected="true" /><select idref="V-219314" selected="true" /><select idref="V-219315" selected="true" /><select idref="V-219316" selected="true" /><select idref="V-219317" selected="true" /><select idref="V-219318" selected="true" /><select idref="V-219319" selected="true" /><select idref="V-219320" selected="true" /><select idref="V-219321" selected="true" /><select idref="V-219322" selected="true" /><select idref="V-219323" selected="true" /><select idref="V-219324" selected="true" /><select idref="V-219325" selected="true" /><select idref="V-219326" selected="true" /><select idref="V-219327" selected="true" /><select idref="V-219328" selected="true" /><select idref="V-219329" selected="true" /><select idref="V-219330" selected="true" /><select idref="V-219331" selected="true" /><select idref="V-219332" selected="true" /><select idref="V-219333" selected="true" /><select idref="V-219334" selected="true" /><select idref="V-219335" selected="true" /><select idref="V-219336" selected="true" /><select idref="V-219337" selected="true" /><select idref="V-219338" selected="true" /><select idref="V-219339" selected="true" /><select idref="V-219340" selected="true" /><select idref="V-219341" selected="true" /><select idref="V-219342" selected="true" /><select idref="V-219343" selected="true" /><select idref="V-219344" selected="true" /><select idref="V-219346" selected="true" /><select idref="V-233779" selected="true" /><select idref="V-233780" selected="true" /></Profile><Profile id="MAC-3_Classified"><title>III - Administrative Classified</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-219147" selected="true" /><select idref="V-219148" selected="true" /><select idref="V-219149" selected="true" /><select idref="V-219150" selected="true" /><select idref="V-219151" selected="true" /><select idref="V-219152" selected="true" /><select idref="V-219153" selected="true" /><select idref="V-219154" selected="true" /><select idref="V-219155" selected="true" /><select idref="V-219156" selected="true" /><select idref="V-219157" selected="true" /><select idref="V-219158" selected="true" /><select idref="V-219159" selected="true" /><select idref="V-219160" selected="true" /><select idref="V-219161" selected="true" /><select idref="V-219162" selected="true" /><select idref="V-219163" selected="true" /><select idref="V-219164" selected="true" /><select idref="V-219165" selected="true" /><select idref="V-219166" selected="true" /><select idref="V-219167" selected="true" /><select idref="V-219168" selected="true" /><select idref="V-219169" selected="true" /><select idref="V-219170" selected="true" /><select idref="V-219172" selected="true" /><select idref="V-219173" selected="true" /><select idref="V-219174" selected="true" /><select idref="V-219175" selected="true" /><select idref="V-219176" selected="true" /><select idref="V-219177" selected="true" /><select idref="V-219178" selected="true" /><select idref="V-219179" selected="true" /><select idref="V-219180" selected="true" /><select idref="V-219181" selected="true" /><select idref="V-219182" selected="true" /><select idref="V-219183" selected="true" /><select idref="V-219184" selected="true" /><select idref="V-219185" selected="true" /><select idref="V-219186" selected="true" /><select idref="V-219187" selected="true" /><select idref="V-219188" selected="true" /><select idref="V-219189" selected="true" /><select idref="V-219190" selected="true" /><select idref="V-219191" selected="true" /><select idref="V-219192" selected="true" /><select idref="V-219193" selected="true" /><select idref="V-219194" selected="true" /><select idref="V-219195" selected="true" /><select idref="V-219196" selected="true" /><select idref="V-219197" selected="true" /><select idref="V-219198" selected="true" /><select idref="V-219199" selected="true" /><select idref="V-219200" selected="true" /><select idref="V-219201" selected="true" /><select idref="V-219202" selected="true" /><select idref="V-219203" selected="true" /><select idref="V-219204" selected="true" /><select idref="V-219205" selected="true" /><select idref="V-219206" selected="true" /><select idref="V-219207" selected="true" /><select idref="V-219208" selected="true" /><select idref="V-219209" selected="true" /><select idref="V-219210" selected="true" /><select idref="V-219211" selected="true" /><select idref="V-219212" selected="true" /><select idref="V-219213" selected="true" /><select idref="V-219214" selected="true" /><select idref="V-219215" selected="true" /><select idref="V-219216" selected="true" /><select idref="V-219217" selected="true" /><select idref="V-219218" selected="true" /><select idref="V-219219" selected="true" /><select idref="V-219220" selected="true" /><select idref="V-219221" selected="true" /><select idref="V-219222" selected="true" /><select idref="V-219223" selected="true" /><select idref="V-219224" selected="true" /><select idref="V-219225" selected="true" /><select idref="V-219226" selected="true" /><select idref="V-219227" selected="true" /><select idref="V-219228" selected="true" /><select idref="V-219229" selected="true" /><select idref="V-219230" selected="true" /><select idref="V-219231" selected="true" /><select idref="V-219232" selected="true" /><select idref="V-219233" selected="true" /><select idref="V-219234" selected="true" /><select idref="V-219235" selected="true" /><select idref="V-219236" selected="true" /><select idref="V-219237" selected="true" /><select idref="V-219238" selected="true" /><select idref="V-219239" selected="true" /><select idref="V-219240" selected="true" /><select idref="V-219241" selected="true" /><select idref="V-219242" selected="true" /><select idref="V-219243" selected="true" /><select idref="V-219244" selected="true" /><select idref="V-219245" selected="true" /><select idref="V-219246" selected="true" /><select idref="V-219247" selected="true" /><select idref="V-219248" selected="true" /><select idref="V-219249" selected="true" /><select idref="V-219250" selected="true" /><select idref="V-219251" selected="true" /><select idref="V-219252" selected="true" /><select idref="V-219253" selected="true" /><select idref="V-219254" selected="true" /><select idref="V-219255" selected="true" /><select idref="V-219256" selected="true" /><select idref="V-219257" selected="true" /><select idref="V-219261" selected="true" /><select idref="V-219262" selected="true" /><select idref="V-219263" selected="true" /><select idref="V-219264" selected="true" /><select idref="V-219265" selected="true" /><select idref="V-219266" selected="true" /><select idref="V-219267" selected="true" /><select idref="V-219268" selected="true" /><select idref="V-219269" selected="true" /><select idref="V-219270" selected="true" /><select idref="V-219271" selected="true" /><select idref="V-219272" selected="true" /><select idref="V-219273" selected="true" /><select idref="V-219274" selected="true" /><select idref="V-219275" selected="true" /><select idref="V-219276" selected="true" /><select idref="V-219277" selected="true" /><select idref="V-219278" selected="true" /><select idref="V-219279" selected="true" /><select idref="V-219280" selected="true" /><select idref="V-219281" selected="true" /><select idref="V-219282" selected="true" /><select idref="V-219283" selected="true" /><select idref="V-219284" selected="true" /><select idref="V-219285" selected="true" /><select idref="V-219286" selected="true" /><select idref="V-219287" selected="true" /><select idref="V-219288" selected="true" /><select idref="V-219289" selected="true" /><select idref="V-219290" selected="true" /><select idref="V-219291" selected="true" /><select idref="V-219292" selected="true" /><select idref="V-219293" selected="true" /><select idref="V-219294" selected="true" /><select idref="V-219295" selected="true" /><select idref="V-219296" selected="true" /><select idref="V-219297" selected="true" /><select idref="V-219298" selected="true" /><select idref="V-219299" selected="true" /><select idref="V-219300" selected="true" /><select idref="V-219301" selected="true" /><select idref="V-219302" selected="true" /><select idref="V-219303" selected="true" /><select idref="V-219304" selected="true" /><select idref="V-219306" selected="true" /><select idref="V-219307" selected="true" /><select idref="V-219308" selected="true" /><select idref="V-219309" selected="true" /><select idref="V-219310" selected="true" /><select idref="V-219311" selected="true" /><select idref="V-219312" selected="true" /><select idref="V-219313" selected="true" /><select idref="V-219314" selected="true" /><select idref="V-219315" selected="true" /><select idref="V-219316" selected="true" /><select idref="V-219317" selected="true" /><select idref="V-219318" selected="true" /><select idref="V-219319" selected="true" /><select idref="V-219320" selected="true" /><select idref="V-219321" selected="true" /><select idref="V-219322" selected="true" /><select idref="V-219323" selected="true" /><select idref="V-219324" selected="true" /><select idref="V-219325" selected="true" /><select idref="V-219326" selected="true" /><select idref="V-219327" selected="true" /><select idref="V-219328" selected="true" /><select idref="V-219329" selected="true" /><select idref="V-219330" selected="true" /><select idref="V-219331" selected="true" /><select idref="V-219332" selected="true" /><select idref="V-219333" selected="true" /><select idref="V-219334" selected="true" /><select idref="V-219335" selected="true" /><select idref="V-219336" selected="true" /><select idref="V-219337" selected="true" /><select idref="V-219338" selected="true" /><select idref="V-219339" selected="true" /><select idref="V-219340" selected="true" /><select idref="V-219341" selected="true" /><select idref="V-219342" selected="true" /><select idref="V-219343" selected="true" /><select idref="V-219344" selected="true" /><select idref="V-219346" selected="true" /><select idref="V-233779" selected="true" /><select idref="V-233780" selected="true" /></Profile><Profile id="MAC-3_Public"><title>III - Administrative Public</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-219147" selected="true" /><select idref="V-219148" selected="true" /><select idref="V-219149" selected="true" /><select idref="V-219150" selected="true" /><select idref="V-219151" selected="true" /><select idref="V-219152" selected="true" /><select idref="V-219153" selected="true" /><select idref="V-219154" selected="true" /><select idref="V-219155" selected="true" /><select idref="V-219156" selected="true" /><select idref="V-219157" selected="true" /><select idref="V-219158" selected="true" /><select idref="V-219159" selected="true" /><select idref="V-219160" selected="true" /><select idref="V-219161" selected="true" /><select idref="V-219162" selected="true" /><select idref="V-219163" selected="true" /><select idref="V-219164" selected="true" /><select idref="V-219165" selected="true" /><select idref="V-219166" selected="true" /><select idref="V-219167" selected="true" /><select idref="V-219168" selected="true" /><select idref="V-219169" selected="true" /><select idref="V-219170" selected="true" /><select idref="V-219172" selected="true" /><select idref="V-219173" selected="true" /><select idref="V-219174" selected="true" /><select idref="V-219175" selected="true" /><select idref="V-219176" selected="true" /><select idref="V-219177" selected="true" /><select idref="V-219178" selected="true" /><select idref="V-219179" selected="true" /><select idref="V-219180" selected="true" /><select idref="V-219181" selected="true" /><select idref="V-219182" selected="true" /><select idref="V-219183" selected="true" /><select idref="V-219184" selected="true" /><select idref="V-219185" selected="true" /><select idref="V-219186" selected="true" /><select idref="V-219187" selected="true" /><select idref="V-219188" selected="true" /><select idref="V-219189" selected="true" /><select idref="V-219190" selected="true" /><select idref="V-219191" selected="true" /><select idref="V-219192" selected="true" /><select idref="V-219193" selected="true" /><select idref="V-219194" selected="true" /><select idref="V-219195" selected="true" /><select idref="V-219196" selected="true" /><select idref="V-219197" selected="true" /><select idref="V-219198" selected="true" /><select idref="V-219199" selected="true" /><select idref="V-219200" selected="true" /><select idref="V-219201" selected="true" /><select idref="V-219202" selected="true" /><select idref="V-219203" selected="true" /><select idref="V-219204" selected="true" /><select idref="V-219205" selected="true" /><select idref="V-219206" selected="true" /><select idref="V-219207" selected="true" /><select idref="V-219208" selected="true" /><select idref="V-219209" selected="true" /><select idref="V-219210" selected="true" /><select idref="V-219211" selected="true" /><select idref="V-219212" selected="true" /><select idref="V-219213" selected="true" /><select idref="V-219214" selected="true" /><select idref="V-219215" selected="true" /><select idref="V-219216" selected="true" /><select idref="V-219217" selected="true" /><select idref="V-219218" selected="true" /><select idref="V-219219" selected="true" /><select idref="V-219220" selected="true" /><select idref="V-219221" selected="true" /><select idref="V-219222" selected="true" /><select idref="V-219223" selected="true" /><select idref="V-219224" selected="true" /><select idref="V-219225" selected="true" /><select idref="V-219226" selected="true" /><select idref="V-219227" selected="true" /><select idref="V-219228" selected="true" /><select idref="V-219229" selected="true" /><select idref="V-219230" selected="true" /><select idref="V-219231" selected="true" /><select idref="V-219232" selected="true" /><select idref="V-219233" selected="true" /><select idref="V-219234" selected="true" /><select idref="V-219235" selected="true" /><select idref="V-219236" selected="true" /><select idref="V-219237" selected="true" /><select idref="V-219238" selected="true" /><select idref="V-219239" selected="true" /><select idref="V-219240" selected="true" /><select idref="V-219241" selected="true" /><select idref="V-219242" selected="true" /><select idref="V-219243" selected="true" /><select idref="V-219244" selected="true" /><select idref="V-219245" selected="true" /><select idref="V-219246" selected="true" /><select idref="V-219247" selected="true" /><select idref="V-219248" selected="true" /><select idref="V-219249" selected="true" /><select idref="V-219250" selected="true" /><select idref="V-219251" selected="true" /><select idref="V-219252" selected="true" /><select idref="V-219253" selected="true" /><select idref="V-219254" selected="true" /><select idref="V-219255" selected="true" /><select idref="V-219256" selected="true" /><select idref="V-219257" selected="true" /><select idref="V-219261" selected="true" /><select idref="V-219262" selected="true" /><select idref="V-219263" selected="true" /><select idref="V-219264" selected="true" /><select idref="V-219265" selected="true" /><select idref="V-219266" selected="true" /><select idref="V-219267" selected="true" /><select idref="V-219268" selected="true" /><select idref="V-219269" selected="true" /><select idref="V-219270" selected="true" /><select idref="V-219271" selected="true" /><select idref="V-219272" selected="true" /><select idref="V-219273" selected="true" /><select idref="V-219274" selected="true" /><select idref="V-219275" selected="true" /><select idref="V-219276" selected="true" /><select idref="V-219277" selected="true" /><select idref="V-219278" selected="true" /><select idref="V-219279" selected="true" /><select idref="V-219280" selected="true" /><select idref="V-219281" selected="true" /><select idref="V-219282" selected="true" /><select idref="V-219283" selected="true" /><select idref="V-219284" selected="true" /><select idref="V-219285" selected="true" /><select idref="V-219286" selected="true" /><select idref="V-219287" selected="true" /><select idref="V-219288" selected="true" /><select idref="V-219289" selected="true" /><select idref="V-219290" selected="true" /><select idref="V-219291" selected="true" /><select idref="V-219292" selected="true" /><select idref="V-219293" selected="true" /><select idref="V-219294" selected="true" /><select idref="V-219295" selected="true" /><select idref="V-219296" selected="true" /><select idref="V-219297" selected="true" /><select idref="V-219298" selected="true" /><select idref="V-219299" selected="true" /><select idref="V-219300" selected="true" /><select idref="V-219301" selected="true" /><select idref="V-219302" selected="true" /><select idref="V-219303" selected="true" /><select idref="V-219304" selected="true" /><select idref="V-219306" selected="true" /><select idref="V-219307" selected="true" /><select idref="V-219308" selected="true" /><select idref="V-219309" selected="true" /><select idref="V-219310" selected="true" /><select idref="V-219311" selected="true" /><select idref="V-219312" selected="true" /><select idref="V-219313" selected="true" /><select idref="V-219314" selected="true" /><select idref="V-219315" selected="true" /><select idref="V-219316" selected="true" /><select idref="V-219317" selected="true" /><select idref="V-219318" selected="true" /><select idref="V-219319" selected="true" /><select idref="V-219320" selected="true" /><select idref="V-219321" selected="true" /><select idref="V-219322" selected="true" /><select idref="V-219323" selected="true" /><select idref="V-219324" selected="true" /><select idref="V-219325" selected="true" /><select idref="V-219326" selected="true" /><select idref="V-219327" selected="true" /><select idref="V-219328" selected="true" /><select idref="V-219329" selected="true" /><select idref="V-219330" selected="true" /><select idref="V-219331" selected="true" /><select idref="V-219332" selected="true" /><select idref="V-219333" selected="true" /><select idref="V-219334" selected="true" /><select idref="V-219335" selected="true" /><select idref="V-219336" selected="true" /><select idref="V-219337" selected="true" /><select idref="V-219338" selected="true" /><select idref="V-219339" selected="true" /><select idref="V-219340" selected="true" /><select idref="V-219341" selected="true" /><select idref="V-219342" selected="true" /><select idref="V-219343" selected="true" /><select idref="V-219344" selected="true" /><select idref="V-219346" selected="true" /><select idref="V-233779" selected="true" /><select idref="V-233780" selected="true" /></Profile><Profile id="MAC-3_Sensitive"><title>III - Administrative Sensitive</title><description>&lt;ProfileDescription&gt;&lt;/ProfileDescription&gt;</description><select idref="V-219147" selected="true" /><select idref="V-219148" selected="true" /><select idref="V-219149" selected="true" /><select idref="V-219150" selected="true" /><select idref="V-219151" selected="true" /><select idref="V-219152" selected="true" /><select idref="V-219153" selected="true" /><select idref="V-219154" selected="true" /><select idref="V-219155" selected="true" /><select idref="V-219156" selected="true" /><select idref="V-219157" selected="true" /><select idref="V-219158" selected="true" /><select idref="V-219159" selected="true" /><select idref="V-219160" selected="true" /><select idref="V-219161" selected="true" /><select idref="V-219162" selected="true" /><select idref="V-219163" selected="true" /><select idref="V-219164" selected="true" /><select idref="V-219165" selected="true" /><select idref="V-219166" selected="true" /><select idref="V-219167" selected="true" /><select idref="V-219168" selected="true" /><select idref="V-219169" selected="true" /><select idref="V-219170" selected="true" /><select idref="V-219172" selected="true" /><select idref="V-219173" selected="true" /><select idref="V-219174" selected="true" /><select idref="V-219175" selected="true" /><select idref="V-219176" selected="true" /><select idref="V-219177" selected="true" /><select idref="V-219178" selected="true" /><select idref="V-219179" selected="true" /><select idref="V-219180" selected="true" /><select idref="V-219181" selected="true" /><select idref="V-219182" selected="true" /><select idref="V-219183" selected="true" /><select idref="V-219184" selected="true" /><select idref="V-219185" selected="true" /><select idref="V-219186" selected="true" /><select idref="V-219187" selected="true" /><select idref="V-219188" selected="true" /><select idref="V-219189" selected="true" /><select idref="V-219190" selected="true" /><select idref="V-219191" selected="true" /><select idref="V-219192" selected="true" /><select idref="V-219193" selected="true" /><select idref="V-219194" selected="true" /><select idref="V-219195" selected="true" /><select idref="V-219196" selected="true" /><select idref="V-219197" selected="true" /><select idref="V-219198" selected="true" /><select idref="V-219199" selected="true" /><select idref="V-219200" selected="true" /><select idref="V-219201" selected="true" /><select idref="V-219202" selected="true" /><select idref="V-219203" selected="true" /><select idref="V-219204" selected="true" /><select idref="V-219205" selected="true" /><select idref="V-219206" selected="true" /><select idref="V-219207" selected="true" /><select idref="V-219208" selected="true" /><select idref="V-219209" selected="true" /><select idref="V-219210" selected="true" /><select idref="V-219211" selected="true" /><select idref="V-219212" selected="true" /><select idref="V-219213" selected="true" /><select idref="V-219214" selected="true" /><select idref="V-219215" selected="true" /><select idref="V-219216" selected="true" /><select idref="V-219217" selected="true" /><select idref="V-219218" selected="true" /><select idref="V-219219" selected="true" /><select idref="V-219220" selected="true" /><select idref="V-219221" selected="true" /><select idref="V-219222" selected="true" /><select idref="V-219223" selected="true" /><select idref="V-219224" selected="true" /><select idref="V-219225" selected="true" /><select idref="V-219226" selected="true" /><select idref="V-219227" selected="true" /><select idref="V-219228" selected="true" /><select idref="V-219229" selected="true" /><select idref="V-219230" selected="true" /><select idref="V-219231" selected="true" /><select idref="V-219232" selected="true" /><select idref="V-219233" selected="true" /><select idref="V-219234" selected="true" /><select idref="V-219235" selected="true" /><select idref="V-219236" selected="true" /><select idref="V-219237" selected="true" /><select idref="V-219238" selected="true" /><select idref="V-219239" selected="true" /><select idref="V-219240" selected="true" /><select idref="V-219241" selected="true" /><select idref="V-219242" selected="true" /><select idref="V-219243" selected="true" /><select idref="V-219244" selected="true" /><select idref="V-219245" selected="true" /><select idref="V-219246" selected="true" /><select idref="V-219247" selected="true" /><select idref="V-219248" selected="true" /><select idref="V-219249" selected="true" /><select idref="V-219250" selected="true" /><select idref="V-219251" selected="true" /><select idref="V-219252" selected="true" /><select idref="V-219253" selected="true" /><select idref="V-219254" selected="true" /><select idref="V-219255" selected="true" /><select idref="V-219256" selected="true" /><select idref="V-219257" selected="true" /><select idref="V-219261" selected="true" /><select idref="V-219262" selected="true" /><select idref="V-219263" selected="true" /><select idref="V-219264" selected="true" /><select idref="V-219265" selected="true" /><select idref="V-219266" selected="true" /><select idref="V-219267" selected="true" /><select idref="V-219268" selected="true" /><select idref="V-219269" selected="true" /><select idref="V-219270" selected="true" /><select idref="V-219271" selected="true" /><select idref="V-219272" selected="true" /><select idref="V-219273" selected="true" /><select idref="V-219274" selected="true" /><select idref="V-219275" selected="true" /><select idref="V-219276" selected="true" /><select idref="V-219277" selected="true" /><select idref="V-219278" selected="true" /><select idref="V-219279" selected="true" /><select idref="V-219280" selected="true" /><select idref="V-219281" selected="true" /><select idref="V-219282" selected="true" /><select idref="V-219283" selected="true" /><select idref="V-219284" selected="true" /><select idref="V-219285" selected="true" /><select idref="V-219286" selected="true" /><select idref="V-219287" selected="true" /><select idref="V-219288" selected="true" /><select idref="V-219289" selected="true" /><select idref="V-219290" selected="true" /><select idref="V-219291" selected="true" /><select idref="V-219292" selected="true" /><select idref="V-219293" selected="true" /><select idref="V-219294" selected="true" /><select idref="V-219295" selected="true" /><select idref="V-219296" selected="true" /><select idref="V-219297" selected="true" /><select idref="V-219298" selected="true" /><select idref="V-219299" selected="true" /><select idref="V-219300" selected="true" /><select idref="V-219301" selected="true" /><select idref="V-219302" selected="true" /><select idref="V-219303" selected="true" /><select idref="V-219304" selected="true" /><select idref="V-219306" selected="true" /><select idref="V-219307" selected="true" /><select idref="V-219308" selected="true" /><select idref="V-219309" selected="true" /><select idref="V-219310" selected="true" /><select idref="V-219311" selected="true" /><select idref="V-219312" selected="true" /><select idref="V-219313" selected="true" /><select idref="V-219314" selected="true" /><select idref="V-219315" selected="true" /><select idref="V-219316" selected="true" /><select idref="V-219317" selected="true" /><select idref="V-219318" selected="true" /><select idref="V-219319" selected="true" /><select idref="V-219320" selected="true" /><select idref="V-219321" selected="true" /><select idref="V-219322" selected="true" /><select idref="V-219323" selected="true" /><select idref="V-219324" selected="true" /><select idref="V-219325" selected="true" /><select idref="V-219326" selected="true" /><select idref="V-219327" selected="true" /><select idref="V-219328" selected="true" /><select idref="V-219329" selected="true" /><select idref="V-219330" selected="true" /><select idref="V-219331" selected="true" /><select idref="V-219332" selected="true" /><select idref="V-219333" selected="true" /><select idref="V-219334" selected="true" /><select idref="V-219335" selected="true" /><select idref="V-219336" selected="true" /><select idref="V-219337" selected="true" /><select idref="V-219338" selected="true" /><select idref="V-219339" selected="true" /><select idref="V-219340" selected="true" /><select idref="V-219341" selected="true" /><select idref="V-219342" selected="true" /><select idref="V-219343" selected="true" /><select idref="V-219344" selected="true" /><select idref="V-219346" selected="true" /><select idref="V-233779" selected="true" /><select idref="V-233780" selected="true" /></Profile><Group id="V-219147"><title>SRG-OS-000080-GPOS-00048</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219147r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010000</version><title>Ubuntu operating systems booted with a BIOS must require authentication upon booting into single-user and maintenance modes.</title><description>&lt;VulnDiscussion&gt;To mitigate the risk of unauthorized access to sensitive information by entities that have been issued certificates by DoD-approved PKIs, all DoD systems (e.g., web servers and web portals) must be properly configured to incorporate access control methods that do not rely solely on the possession of a certificate for access. Successful authentication must not automatically give an entity access to an asset or security boundary. Authorization procedures and controls must be implemented to ensure each authenticated entity also has a validated and current authorization. Authorization is the process of determining whether an entity, once authenticated, is permitted to access a specific asset. Information systems use access control policies and enforcement mechanisms to implement this requirement.
+
+Access control policies include: identity-based policies, role-based policies, and attribute-based policies. Access enforcement mechanisms include: access control lists, access control matrices, and cryptography. These policies and mechanisms must be employed by the application to control access between users (or processes acting on behalf of users) and objects (e.g., devices, files, records, processes, programs, and domains) in the information system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">V-100519</ident><ident system="http://cyber.mil/legacy">SV-109623</ident><ident system="http://cyber.mil/cci">CCI-000213</ident><fixtext fixref="F-20871r304770_fix">Configure the system to require a password for authentication upon booting into single-user and maintenance modes.
+
+Generate an encrypted (grub) password for root with the following command:
+
+# grub-mkpasswd-pbkdf2
+Enter Password:
+Reenter Password:
+PBKDF2 hash of your password is grub.pbkdf2.sha512.10000.MFU48934NJD84NF8NSD39993JDHF84NG
+
+Using the hash from the output, modify the "/etc/grub.d/40_custom" file with the following command to add a boot password:
+
+# sudo sed -i '$i set superusers=\"root\"\npassword_pbkdf2 root &lt;hash&gt;' /etc/grub.d/40_custom
+
+where &lt;hash&gt; is the hash generated by grub-mkpasswd-pbdkf2 command.
+
+Generate an updated "grub.conf" file with the new password by using the following command:
+
+# update-grub</fixtext><fix id="F-20871r304770_fix" /><check system="C-20872r304769_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that an encrypted root password is set. This is only applicable on systems that use a basic Input/Output System BIOS.
+
+Run the following command to verify the encrypted password is set:
+
+# grep –i password /boot/grub/grub.cfg
+
+password_pbkdf2 root grub.pbkdf2.sha512.10000.MFU48934NJA87HF8NSD34493GDHF84NG
+
+If the root password entry does not begin with “password_pbkdf2”, this is a finding.</check-content></check></Rule></Group><Group id="V-219148"><title>SRG-OS-000080-GPOS-00048</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219148r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010001</version><title>Ubuntu operating systems booted with United Extensible Firmware Interface (UEFI) implemented must require authentication upon booting into single-user mode and maintenance.</title><description>&lt;VulnDiscussion&gt;To mitigate the risk of unauthorized access to sensitive information by entities that have been issued certificates by DoD-approved PKIs, all DoD systems (e.g., web servers and web portals) must be properly configured to incorporate access control methods that do not rely solely on the possession of a certificate for access. Successful authentication must not automatically give an entity access to an asset or security boundary. Authorization procedures and controls must be implemented to ensure each authenticated entity also has a validated and current authorization. Authorization is the process of determining whether an entity, once authenticated, is permitted to access a specific asset. Information systems use access control policies and enforcement mechanisms to implement this requirement.
+
+Access control policies include: identity-based policies, role-based policies, and attribute-based policies. Access enforcement mechanisms include: access control lists, access control matrices, and cryptography. These policies and mechanisms must be employed by the application to control access between users (or processes acting on behalf of users) and objects (e.g., devices, files, records, processes, programs, and domains) in the information system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109625</ident><ident system="http://cyber.mil/legacy">V-100521</ident><ident system="http://cyber.mil/cci">CCI-000213</ident><fixtext fixref="F-20872r304773_fix">Configure the system to require a password for authentication upon booting into single-user and maintenance modes.
+
+Generate an encrypted (grub) password for root with the following command:
+
+# grub-mkpasswd-pbkdf2
+Enter Password:
+Reenter Password:
+PBKDF2 hash of your password is grub.pbkdf2.sha512.10000.MFU48934NJD84NF8NSD39993JDHF84NG
+
+Using the hash from the output, modify the "/etc/grub.d/40_custom" file with the following command to add a boot password:
+
+# sudo sed -i '$i set superusers=\"root\"\npassword_pbkdf2 root &lt;hash&gt;' /etc/grub.d/40_custom
+
+where &lt;hash&gt; is the hash generated by grub-mkpasswd-pbdkf2 command.
+
+Generate an updated "grub.conf" file with the new password by using the following command:
+
+# update-grub</fixtext><fix id="F-20872r304773_fix" /><check system="C-20873r304772_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that an encrypted root password is set. This is only applicable on Ubuntu operating systems that use UEFI.
+
+Run the following command to verify the encrypted password is set:
+
+# grep –i password /boot/efi/EFI/grub.cfg
+password_pbkdf2 root grub.pbkdf2.sha512.10000.VeryLongString
+
+If the root password entry does not begin with “password_pbkdf2”, this is a finding.</check-content></check></Rule></Group><Group id="V-219149"><title>SRG-OS-000254-GPOS-00095</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219149r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010002</version><title>The Ubuntu operating system must initiate session audits at system startup.</title><description>&lt;VulnDiscussion&gt;If auditing is enabled late in the startup process, the actions of some startup processes may not be audited. Some audit systems also maintain state information only available if auditing is enabled before a given process is created.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109627</ident><ident system="http://cyber.mil/legacy">V-100523</ident><ident system="http://cyber.mil/cci">CCI-001464</ident><fixtext fixref="F-20873r304776_fix">Configure the Ubuntu operating system to produce audit records at system startup. 
+
+Edit /etc/default/grub file and add "audit=1" to the GRUB_CMDLINE_LINUX option.
+
+To update the grub config file run,
+
+sudo update-grub</fixtext><fix id="F-20873r304776_fix" /><check system="C-20874r304775_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enables auditing at system startup. 
+
+Check that the auditing is enabled in grub with the following command:
+
+grep "^\s*linux" /boot/grub/grub.cfg
+
+linux /vmlinuz-4.15.0-55-generic root=/dev/mapper/ubuntu--vg-root ro quiet splash $vt_handoff audit=1
+linux /vmlinuz-4.15.0-55-generic root=/dev/mapper/ubuntu--vg-root ro recovery nomodeset audit=1
+
+If any linux lines do not contain "audit=1", this is a finding.</check-content></check></Rule></Group><Group id="V-219150"><title>SRG-OS-000185-GPOS-00079</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219150r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010003</version><title>Ubuntu operating systems handling data requiring data at rest protections must employ cryptographic mechanisms to prevent unauthorized disclosure and modification of the information at rest.</title><description>&lt;VulnDiscussion&gt;Information at rest refers to the state of information when it is located on a secondary storage device (e.g., disk drive and tape drive, when used for backups) within an operating system.
+
+This requirement addresses protection of user-generated data, as well as Ubuntu operating system-specific configuration data. Organizations may choose to employ different mechanisms to achieve confidentiality and integrity protections, as appropriate, in accordance with the security category and/or classification of the information.
+
+Satisfies: SRG-OS-000185-GPOS-00079, SRG-OS-000404-GPOS-00183, SRG-OS-000405-GPOS-00184&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109629</ident><ident system="http://cyber.mil/legacy">V-100525</ident><ident system="http://cyber.mil/cci">CCI-002475</ident><ident system="http://cyber.mil/cci">CCI-002476</ident><ident system="http://cyber.mil/cci">CCI-001199</ident><fixtext fixref="F-20874r304779_fix">To encrypt an entire partition, dedicate a partition for encryption in the partition layout.
+
+Note: Encrypting a partition in an already-installed system is more difficult because the existing partitions must be resized and changed.</fixtext><fix id="F-20874r304779_fix" /><check system="C-20875r304778_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>If there is a documented and approved reason for not having data-at-rest encryption, this requirement is Not Applicable.
+
+Verify the Ubuntu operating system prevents unauthorized disclosure or modification of all information requiring at rest protection by using disk encryption. 
+
+Determine the partition layout for the system with the following command:
+
+#sudo fdisk -l
+(..)
+Disk /dev/vda: 15 GiB, 16106127360 bytes, 31457280 sectors
+Units: sectors of 1 * 512 = 512 bytes
+Sector size (logical/physical): 512 bytes / 512 bytes
+I/O size (minimum/optimal): 512 bytes / 512 bytes
+Disklabel type: gpt
+Disk identifier: 83298450-B4E3-4B19-A9E4-7DF147A5FEFB
+
+Device Start End Sectors Size Type
+/dev/vda1 2048 4095 2048 1M BIOS boot
+/dev/vda2 4096 2101247 2097152 1G Linux filesystem
+/dev/vda3 2101248 31455231 29353984 14G Linux filesystem
+(...)
+
+Verify that the system partitions are all encrypted with the following command:
+
+# more /etc/crypttab
+
+Every persistent disk partition present must have an entry in the file. If any partitions other than the boot partition or pseudo file systems (such as /proc or /sys) are not listed, this is a finding.</check-content></check></Rule></Group><Group id="V-219151"><title>SRG-OS-000478-GPOS-00223</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219151r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010005</version><title>The Ubuntu operating system must implement NIST FIPS-validated cryptography to protect classified information and for the following: to provision digital signatures, to generate cryptographic hashes, and to protect unclassified information requiring confidentiality and cryptographic protection in accordance with applicable federal laws, Executive Orders, directives, policies, regulations, and standards.</title><description>&lt;VulnDiscussion&gt;Use of weak or untested encryption algorithms undermines the purposes of utilizing encryption to protect data. The operating system must implement cryptographic modules adhering to the higher standards approved by the federal government since this provides assurance they have been tested and validated.
+
+Satisfies: SRG-OS-000478-GPOS-00223, SRG-OS-000396-GPOS-00176&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109631</ident><ident system="http://cyber.mil/legacy">V-100527</ident><ident system="http://cyber.mil/cci">CCI-002450</ident><fixtext fixref="F-20875r304782_fix">Configure the system to run in FIPS mode. Add "fips=1" to the kernel parameter during the Ubuntu operating systems install.
+
+Enabling a FIPS mode on a pre-existing system involves a number of modifications to the Ubuntu operating system. Refer to the Ubuntu Server 18.04 FIPS 140-2 security policy document for instructions. A subscription to the "Ubuntu Advantage" plan is required in order to obtain the FIPS Kernel cryptographic modules and enable FIPS.</fixtext><fix id="F-20875r304782_fix" /><check system="C-20876r304781_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system is configured to run in FIPS mode.
+
+Check that the system is configured to run in FIPS mode with the following command:
+
+# grep -i 1 /proc/sys/crypto/fips_enabled
+1
+
+If a value of "1" is not returned, this is a finding.</check-content></check></Rule></Group><Group id="V-219152"><title>SRG-OS-000343-GPOS-00134</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219152r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010006</version><title>The Ubuntu operating system must immediately notify the SA and ISSO (at a minimum) when allocated audit record storage volume reaches 75% of the repository maximum audit record storage capacity.</title><description>&lt;VulnDiscussion&gt;If security personnel are not notified immediately when storage volume reaches 75% utilization, they are unable to plan for audit record storage capacity expansion.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109633</ident><ident system="http://cyber.mil/legacy">V-100529</ident><ident system="http://cyber.mil/cci">CCI-001855</ident><fixtext fixref="F-20876r304785_fix">Edit /etc/audit/auditd.conf and set the space_left_action parameter to "exec" or "email". 
+
+If the space_left_action parameter is set to "email" set the action_mail_acct parameter to an e-mail address for the System Administrator (SA) and Information System Security Officer (ISSO).
+
+If the space_left_action parameter is set to "exec", make sure the command being execute notifies the System Administrator (SA) and Information System Security Officer (ISSO).
+
+Edit /etc/audit/auditd.conf and set the space_left parameter to be, at least, 25% of the repository maximum audit record storage capacity.</fixtext><fix id="F-20876r304785_fix" /><check system="C-20877r304784_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system notifies the System Administrator (SA) and Information System Security Officer (ISSO) (at a minimum) when allocated audit record storage volume reaches 75% of the repository maximum audit record storage capacity.
+
+Check that the Ubuntu operating system notifies the SA and ISSO (at a minimum) when allocated audit record storage volume reaches 75% of the repository maximum audit record storage capacity with the following command:
+
+# sudo grep ^space_left_action /etc/audit/auditd.conf
+
+space_left_action email
+
+# sudo grep ^space_left /etc/audit/auditd.conf
+
+space_left 250000
+
+If the "space_left" parameter is missing, set to blanks or set to a value less than 25% of the space free in the allocated audit record storage, this is a finding.
+
+If the "space_left_action" parameter is missing or set to blanks, this is a finding.
+
+If the "space_left_action" is set to "syslog", the system logs the event, but does not generate a notification, so this is a finding.
+
+If the "space_left_action" is set to "exec", the system executes a designated script. If this script informs the SA of the event, this is not a finding.
+
+If the "space_left_action" is set to "email" check the value of the "action_mail_acct" parameter with the following command:
+
+# sudo grep action_mail_acct /etc/audit/auditd.conf
+
+action_mail_acct root@localhost
+
+The "action_mail_acct" parameter, if missing, defaults to "root". If the "action_mail_acct parameter" is not set to the e-mail address of the system administrator(s) and/or ISSO, this is a finding. 
+
+Note: If the email address of the system administrator is on a remote system a mail package must be available.</check-content></check></Rule></Group><Group id="V-219153"><title>SRG-OS-000479-GPOS-00224</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219153r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010007</version><title>The Ubuntu operating system audit event multiplexor must be configured to off-load audit logs onto a different system in real time, if the system is interconnected.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
+
+Off-loading is a common process in information systems with limited audit storage capacity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109635</ident><ident system="http://cyber.mil/legacy">V-100531</ident><ident system="http://cyber.mil/cci">CCI-001851</ident><fixtext fixref="F-20877r304788_fix">Configure the audit event multiplexor to off-load audit records to a different system or storage media from the system being audited.
+
+Install the audisp-remote plugin:
+
+# sudo apt-get install audispd-plugins -y
+
+Set the audisp-remote plugin as active, by editing the /etc/audisp/plugins.d/au-remote.conf file:
+
+# sudo sed -i -E 's/active\s*=\s*no/active = yes/' /etc/audisp/plugins.d/au-remote.conf
+
+Set the address of the remote machine, by editing the /etc/audisp/audisp-remote.conf file:
+
+# sudo sed -i -E 's/(remote_server\s*=).*/\1 &lt;remote addr&gt;/' audisp-remote.conf
+
+where &lt;remote addr&gt; must be substituted by the address of the remote server receiving the audit log.
+
+Make the audit service reload its configuration files:
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-20877r304788_fix" /><check system="C-20878r304787_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the audit event multiplexor is configured to off-load audit records to a different system or storage media from the system being audited.
+
+Check that audisp-remote plugin is installed:
+
+# sudo dpkg -s audispd-plugins
+
+If status is "not installed", this is a finding.
+
+Check that the records are being off-loaded to a remote server with the following command:
+
+# sudo grep -i active /etc/audisp/plugins.d/au-remote.conf
+
+active = yes
+
+If "active" is not set to "yes", or the line is commented out, this is a finding.
+
+Check that audisp-remote plugin is configured to send audit logs to a different system:
+
+# sudo grep -i ^remote_server /etc/audisp/audisp-remote.conf 
+
+remote_server = 192.168.122.126
+
+If the remote_server parameter is not set or is set with a local address, or is set with invalid address, this is a finding.</check-content></check></Rule></Group><Group id="V-219154"><title>SRG-OS-000479-GPOS-00224</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219154r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010008</version><title>The Ubuntu operating system must have a crontab script running weekly to off-load audit events of standalone systems.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
+
+Off-loading is a common process in information systems with limited audit storage capacity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109637</ident><ident system="http://cyber.mil/legacy">V-100533</ident><ident system="http://cyber.mil/cci">CCI-001851</ident><fixtext fixref="F-20878r304791_fix">Create a script which off-loads audit logs to external media and runs weekly.
+
+Script must be located into the /etc/cron.weekly directory.</fixtext><fix id="F-20878r304791_fix" /><check system="C-20879r304790_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify there is a script which off-loads audit data and if that script runs weekly.
+
+Check if there is a script in the /etc/cron.weekly directory which off-loads audit data:
+
+# sudo ls /etc/cron.weekly
+
+audit-offload
+
+Check if the script inside the file does offloading of audit logs to an external media.
+
+If the script file does not exist or if the script file doesn't offload audit logs, this is a finding.</check-content></check></Rule></Group><Group id="V-219155"><title>SRG-OS-000366-GPOS-00153</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219155r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010016</version><title>Advance package Tool (APT) must be configured to prevent the installation of patches, service packs, device drivers, or Ubuntu operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization.</title><description>&lt;VulnDiscussion&gt;Changes to any software components can have significant effects on the overall security of the Ubuntu operating system. This requirement ensures the software has not been tampered with and that it has been provided by a trusted vendor.
+
+Accordingly, patches, service packs, device drivers, or Ubuntu operating system components must be signed with a certificate recognized and approved by the organization.
+
+Verifying the authenticity of the software prior to installation validates the integrity of the patch or upgrade received from a vendor. This ensures the software has not been tampered with and that it has been provided by a trusted vendor. Self-signed certificates are disallowed by this requirement. The Ubuntu operating system should not have to verify the software again. This requirement does not mandate DoD certificates for this purpose; however, the certificate used to verify the software must be from an approved CA.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109639</ident><ident system="http://cyber.mil/legacy">V-100535</ident><ident system="http://cyber.mil/cci">CCI-001749</ident><fixtext fixref="F-20879r304794_fix">Configure Advance package Tool (APT) to prevent the installation of patches, service packs, device drivers, or Ubuntu operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization.
+
+Remove/Update any APT configuration file that contain the variable "AllowUnauthenticated" to "false", or remove "AllowUnauthenticated" entirely from each file. Below is an example of setting the "AllowUnauthenticated" variable to "false":
+
+APT::Get::AllowUnauthenticated "false";</fixtext><fix id="F-20879r304794_fix" /><check system="C-20880r304793_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that Advance package Tool (APT) is configured to prevent the installation of patches, service packs, device drivers, or Ubuntu operating system components without verification they have been digitally signed using a certificate that is recognized and approved by the organization.
+
+Check that the "AllowUnauthenticated" variable is not set at all or set to "false" with the following command:
+
+# grep AllowUnauthenticated /etc/apt/apt.conf.d/*
+/etc/apt/apt.conf.d/01-vendor-Ubuntu:APT::Get::AllowUnauthenticated "false";
+
+If any of the files returned from the command with "AllowUnauthenticated" set to "true", this is a finding.</check-content></check></Rule></Group><Group id="V-219156"><title>SRG-OS-000437-GPOS-00194</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219156r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010017</version><title>The Ubuntu operating system must be configured so that Advance package Tool (APT) removes all software components after updated versions have been installed.</title><description>&lt;VulnDiscussion&gt;Previous versions of software components that are not removed from the information system after updates have been installed may be exploited by adversaries. Some information technology products may remove older versions of software automatically from the information system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109641</ident><ident system="http://cyber.mil/legacy">V-100537</ident><ident system="http://cyber.mil/cci">CCI-002617</ident><fixtext fixref="F-20880r304797_fix">Configure APT to remove all software components after updated versions have been installed.
+
+Add or updated the following options to the "/etc/apt/apt.conf.d/50unattended-upgrades" file:
+
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";</fixtext><fix id="F-20880r304797_fix" /><check system="C-20881r304796_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify Advance package Tool (APT) is configured to remove all software components after updated versions have been installed.
+
+Check that APT is configured to remove all software components after updating with the following command:
+
+# grep -i remove-unused /etc/apt/apt.conf.d/50unattended-upgrades
+Unattended-Upgrade::Remove-Unused-Dependencies "true";
+Unattended-Upgrade::Remove-Unused-Kernel-Packages "true";
+
+If the "::Remove-Unused-Dependencies" and "::Remove-Unused-Kernel-Packages" parameters are not set to "true", or are missing, or are commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219157"><title>SRG-OS-000095-GPOS-00049</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219157r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010018</version><title>The Ubuntu operating system must not have the Network Information Service (NIS) package installed.</title><description>&lt;VulnDiscussion&gt;Removing the Network Information Service (NIS) package decreases the risk of the accidental (or intentional) activation of NIS or NIS+ services.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109643</ident><ident system="http://cyber.mil/legacy">V-100539</ident><ident system="http://cyber.mil/cci">CCI-000381</ident><fixtext fixref="F-20881r304800_fix">Configure the Ubuntu operating system to disable non-essential capabilities by removing the Network Information Service (NIS) package from the system with the following command:
+
+# sudo apt-get remove nis</fixtext><fix id="F-20881r304800_fix" /><check system="C-20882r304799_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Network Information Service (NIS) package is not installed on the Ubuntu operating system.
+
+Check to see if the NIS package is installed with the following command:
+
+# dpkg -l | grep nis
+
+If the NIS package is installed, this is a finding.</check-content></check></Rule></Group><Group id="V-219158"><title>SRG-OS-000095-GPOS-00049</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219158r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010019</version><title>The Ubuntu operating system must not have the rsh-server package installed.</title><description>&lt;VulnDiscussion&gt;It is detrimental for Ubuntu operating systems to provide, or install by default, functionality exceeding requirements or mission objectives. These unnecessary capabilities or services are often overlooked and therefore may remain unsecured. They increase the risk to the platform by providing additional attack vectors.
+
+Ubuntu operating systems are capable of providing a wide variety of functions and services. Some of the functions and services, provided by default, may not be necessary to support essential organizational operations (e.g., key missions, functions).
+
+The rsh-server service provides an unencrypted remote access service that does not provide for the confidentiality and integrity of user passwords or the remote session and has very weak authentication.
+
+If a privileged user were to log on using this service, the privileged user password could be compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109645</ident><ident system="http://cyber.mil/legacy">V-100541</ident><ident system="http://cyber.mil/cci">CCI-000381</ident><fixtext fixref="F-20882r304803_fix">Configure the Ubuntu operating system to disable non-essential capabilities by removing the rsh-server package from the system with the following command:
+
+# sudo apt-get remove rsh-server</fixtext><fix id="F-20882r304803_fix" /><check system="C-20883r304802_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Check to see if the rsh-server package is installed with the following command:
+
+# dpkg -l | grep rsh-server
+
+If the rsh-server package is installed, this is a finding.</check-content></check></Rule></Group><Group id="V-219159"><title>SRG-OS-000191-GPOS-00080</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219159r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010021</version><title>The Ubuntu operating system must deploy Endpoint Security for Linux Threat Prevention (ENSLTP).</title><description>&lt;VulnDiscussion&gt;Without the use of automated mechanisms to scan for security flaws on a continuous and/or periodic basis, the operating system or other system components may remain vulnerable to the exploits presented by undetected software flaws.
+
+To support this requirement, the Ubuntu operating system may have an integrated solution incorporating continuous scanning using HBSS and periodic scanning using other tools, as specified in the requirement.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">V-100545</ident><ident system="http://cyber.mil/legacy">SV-109649</ident><ident system="http://cyber.mil/cci">CCI-001233</ident><fixtext fixref="F-20883r608749_fix">Configure the Ubuntu operating system to use ENSLTP.
+
+Install the mfetp package,
+
+# sudo apt-get install mfetp</fixtext><fix id="F-20883r608749_fix" /><check system="C-20884r608748_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Check that the "mfetp" package has been installed:
+
+# dpkg -l | grep mfetp
+
+If the "mfetp" package is not installed, this is a finding.
+
+Check that the daemon is running:
+
+# /opt/McAfee/ens/tp/init/mfetpd-control.sh status
+
+If the daemon is not running, this is a finding.</check-content></check></Rule></Group><Group id="V-219160"><title>SRG-OS-000269-GPOS-00103</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219160r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010022</version><title>The Ubuntu operating system must be configured to preserve log records from failure events.</title><description>&lt;VulnDiscussion&gt;Failure to a known state can address safety or security in accordance with the mission/business needs of the organization. Failure to a known secure state helps prevent a loss of confidentiality, integrity, or availability in the event of a failure of the information system or a component of the system. 
+
+Preserving operating system state information helps to facilitate operating system restart and return to the operational mode of the organization with least disruption to mission/business processes.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109651</ident><ident system="http://cyber.mil/legacy">V-100547</ident><ident system="http://cyber.mil/cci">CCI-001665</ident><fixtext fixref="F-20884r304809_fix">Configure the log service to collect failure events.
+
+Install the log service (if the log service is not already installed) with the following command:
+
+# sudo apt-get install rsyslog
+
+Enable the log service with the following command:
+
+# sudo systemctl enable rsyslog
+
+Restart the log service with the following command:
+
+# sudo systemctl restart rsyslog</fixtext><fix id="F-20884r304809_fix" /><check system="C-20885r304808_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the log service is configured to collect system failure events.
+
+Check that the log service is installed properly with the following command:
+
+# dpkg -l | grep rsyslog
+
+ii rsyslog 8.32.0-1ubuntu4 amd64 reliable system and kernel logging daemon
+
+If the "rsyslog" package is not installed, this is a finding.
+
+Check that the log service is enabled with the following command:
+
+# sudo systemctl is-enabled rsyslog
+
+enabled
+
+If the command above returns "disabled", this is a finding.
+
+Check that the log service is properly running and active on the system with the following command:
+
+# systemctl is-active rsyslog
+
+active
+
+If the command above returns "inactive", this is a finding.</check-content></check></Rule></Group><Group id="V-219161"><title>SRG-OS-000297-GPOS-00115</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219161r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010023</version><title>The Ubuntu operating system must have an application firewall installed in order to control remote access methods.</title><description>&lt;VulnDiscussion&gt;Remote access services, such as those providing remote access to network devices and information systems, which lack automated control capabilities, increase risk and make remote user access management difficult at best.
+
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+Ubuntu operating system functionality (e.g., RDP) must be capable of taking enforcement action if the audit reveals unauthorized activity. Automated control of remote access sessions allows organizations to ensure ongoing compliance with remote access policies by enforcing connection rules of remote access applications on a variety of information system components (e.g., servers, workstations, notebook computers, smartphones, and tablets).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109653</ident><ident system="http://cyber.mil/legacy">V-100549</ident><ident system="http://cyber.mil/cci">CCI-002314</ident><fixtext fixref="F-20885r304812_fix">Install the Uncomplicated Firewall by using the following command:
+
+# sudo apt-get install ufw</fixtext><fix id="F-20885r304812_fix" /><check system="C-20886r304811_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Uncomplicated Firewall is installed.
+
+Check that the Uncomplicated Firewall is installed with the following command:
+
+# dpkg -l | grep ufw
+
+ii ufw 0.35-0Ubuntu2
+
+If the "ufw" package is not installed, ask the System Administrator is another application firewall is installed. If no application firewall is installed this is a finding.</check-content></check></Rule></Group><Group id="V-219162"><title>SRG-OS-000342-GPOS-00133</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219162r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010025</version><title>The Ubuntu operating system audit event multiplexor must be configured to off-load audit logs onto a different system or storage media from the system being audited.</title><description>&lt;VulnDiscussion&gt;Information stored in one location is vulnerable to accidental or incidental deletion or alteration.
+
+Off-loading is a common process in information systems with limited audit storage capacity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109655</ident><ident system="http://cyber.mil/legacy">V-100551</ident><ident system="http://cyber.mil/cci">CCI-001851</ident><fixtext fixref="F-20886r304815_fix">Configure the audit event multiplexor to off-load audit records to a different system or storage media from the system being audited.
+
+Install the audisp-remote plugin:
+
+# sudo apt-get install audispd-plugins -y
+
+Set the audisp-remote plugin as active, by editing the /etc/audisp/plugins.d/au-remote.conf file:
+
+# sudo sed -i -E 's/active\s*=\s*no/active = yes/' /etc/audisp/plugins.d/au-remote.conf
+
+Set the address of the remote machine, by editing the /etc/audisp/audisp-remote.conf file:
+
+# sudo sed -i -E 's/(remote_server\s*=).*/\1 &lt;remote addr&gt;/' audisp-remote.conf
+
+where &lt;remote addr&gt; must be substituted by the address of the remote server receiving the audit log.
+
+Make the audit service reload its configuration files:
+
+# sudo systemctl restart auditd.service</fixtext><fix id="F-20886r304815_fix" /><check system="C-20887r466198_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the audit event multiplexor is configured to off-load audit records to a different system or storage media from the system being audited.
+
+Check that audisp-remote plugin is installed:
+
+# sudo dpkg -s audispd-plugins
+
+If status is "not installed", verify that another method to off-load audit logs has been implemented.
+
+Check that the records are being off-loaded to a remote server with the following command:
+
+# sudo grep -i active /etc/audisp/plugins.d/au-remote.conf
+
+active = yes
+
+If "active" is not set to "yes", or the line is commented out, ask the System Administrator to indicate how the audit logs are off-loaded to a different system or storage media.
+
+If there is no evidence that the system is configured to off-load audit logs to a different system or storage media, this is a finding.</check-content></check></Rule></Group><Group id="V-219163"><title>SRG-OS-000383-GPOS-00166</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219163r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010030</version><title>The Ubuntu operating system must be configured such that Pluggable Authentication Module (PAM) prohibits the use of cached authentications after one day.</title><description>&lt;VulnDiscussion&gt;If cached authentication information is out-of-date, the validity of the authentication information may be questionable.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109657</ident><ident system="http://cyber.mil/legacy">V-100553</ident><ident system="http://cyber.mil/cci">CCI-002007</ident><fixtext fixref="F-20887r304818_fix">Configure Pluggable Authentication Module (PAM) to prohibit the use of cached authentications after one day. Add or change the following line in "/etc/sssd/sssd.conf" just below the line "[pam]".
+
+offline_credentials_expiration = 1
+
+Note: It is valid for this configuration to be in a file with a name that ends with ".conf" and does not begin with a "." in the /etc/sssd/conf.d/ directory instead of the /etc/sssd/sssd.conf file.</fixtext><fix id="F-20887r304818_fix" /><check system="C-20888r304817_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>If smart card authentication is not being used on the system this item is Not Applicable.
+
+Verify that Pluggable Authentication Module (PAM) prohibits the use of cached authentications after one day.
+
+Check that PAM prohibits the use of cached authentications after one day with the following command:
+
+# sudo grep offline_credentials_expiration /etc/sssd/sssd.conf /etc/sssd/conf.d/*.conf
+
+offline_credentials_expiration = 1
+
+If "offline_credentials_expiration" is not set to a value of "1", in /etc/sssd/sssd.conf or in a file with a name ending in .conf in the /etc/sssd/conf.d/ directory, this is a finding.</check-content></check></Rule></Group><Group id="V-219164"><title>SRG-OS-000480-GPOS-00226</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219164r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010031</version><title>The Ubuntu operating system must enforce a delay of at least 4 seconds between logon prompts following a failed logon attempt.</title><description>&lt;VulnDiscussion&gt;Limiting the number of logon attempts over a certain time interval reduces the chances that an unauthorized user may gain access to an account.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109659</ident><ident system="http://cyber.mil/legacy">V-100555</ident><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-20888r304821_fix">Configure the Ubuntu operating system to enforce a delay of at least 4 seconds between logon prompts following a failed logon attempt.
+
+Edit the file "/etc/pam.d/common-auth" and set the parameter "pam_faildelay" to a value of 4000000 or greater:
+
+auth required pam_faildelay.so delay=4000000</fixtext><fix id="F-20888r304821_fix" /><check system="C-20889r304820_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enforces a delay of at least 4 seconds between logon prompts following a failed logon attempt.
+
+Check that the Ubuntu operating system enforces a delay of at least 4 seconds between logon prompts with the following command:
+
+# grep pam_faildelay /etc/pam.d/common-auth
+
+auth required pam_faildelay.so delay=4000000
+
+If the line is not present, or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219165"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219165r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010032</version><title>The Ubuntu operating system must display the date and time of the last successful account logon upon logon.</title><description>&lt;VulnDiscussion&gt;Configuring the Ubuntu operating system to implement organization-wide security implementation guides and security checklists ensures compliance with federal standards and establishes a common security baseline across DoD that reflects the most restrictive security posture consistent with operational requirements.
+
+Configuration settings are the set of parameters that can be changed in hardware, software, or firmware components of the system that affect the security posture and/or functionality of the system. Security-related parameters are those parameters impacting the security state of the system, including the parameters required to satisfy other security control requirements. Security-related parameters include, for example: registry settings; account, file, directory permission settings; and settings for functions, ports, protocols, services, and remote connections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109661</ident><ident system="http://cyber.mil/legacy">V-100557</ident><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-20889r304824_fix">Configure the Ubuntu operating system to provide users with feedback on when account accesses last occurred by setting the required configuration options in "/etc/pam.d/postlogin-ac". 
+
+Add the following line to the top of "/etc/pam.d/login":
+
+session required pam_lastlog.so showfailed</fixtext><fix id="F-20889r304824_fix" /><check system="C-20890r304823_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify users are provided with feedback on when account accesses last occurred.
+
+Check that "pam_lastlog" is used and not silent with the following command:
+
+# grep pam_lastlog /etc/pam.d/login
+
+session required pam_lastlog.so showfailed
+
+If "pam_lastlog" is missing from "/etc/pam.d/login" file, is not "required", or the "silent" option is present, this is a finding.</check-content></check></Rule></Group><Group id="V-219166"><title>SRG-OS-000021-GPOS-00005</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219166r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010033</version><title>The Ubuntu operating system must be configured so that three consecutive invalid logon attempts by a user automatically locks the account until released by an administrator.</title><description>&lt;VulnDiscussion&gt;By limiting the number of failed logon attempts, the risk of unauthorized system access via user password guessing, otherwise known as brute-force attacks, is reduced. Limits are imposed by locking the account.
+Satisfies: SRG-OS-000329-GPOS-00128&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109663</ident><ident system="http://cyber.mil/legacy">V-100559</ident><ident system="http://cyber.mil/cci">CCI-000044</ident><ident system="http://cyber.mil/cci">CCI-002238</ident><fixtext fixref="F-20890r569454_fix">Configure the Ubuntu operating system to lock an account after three unsuccessful login attempts. 
+
+Edit the /etc/pam.d/common-auth file. The pam_tally2.so entry must be placed at the top of the "auth" stack. So add the following line before the first "auth" entry in the file.
+
+auth required pam_tally2.so onerr=fail deny=3</fixtext><fix id="F-20890r569454_fix" /><check system="C-20891r569453_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Check that Ubuntu operating system locks an account after three unsuccessful login attempts with following command:
+
+# grep pam_tally2 /etc/pam.d/common-auth 
+
+auth required pam_tally2.so onerr=fail deny=3
+
+If no line is returned or the line is commented out, this is a finding.
+If the line is missing "onerr=fail", this is a finding.
+If the line has "deny" set to a value more than 3, this is a finding.</check-content></check></Rule></Group><Group id="V-219167"><title>SRG-OS-000024-GPOS-00007</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219167r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010035</version><title>The Ubuntu operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting local access to the system via a graphical user logon.</title><description>&lt;VulnDiscussion&gt;The banner must be acknowledged by the user prior to allowing the user access to the operating system. This provides assurance that the user has seen the message and accepted the conditions for access. If the consent banner is not acknowledged by the user, DoD will not be in compliance with system use notifications required by law.
+
+To establish acceptance of the application usage policy, a click-through banner at system logon is required. The system must prevent further activity until the user executes a positive action to manifest agreement by clicking on a box indicating "OK".&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109665</ident><ident system="http://cyber.mil/legacy">V-100561</ident><ident system="http://cyber.mil/cci">CCI-000050</ident><fixtext fixref="F-20891r304830_fix">Edit the /etc/gdm3/greeter.dconf-defaults file.
+
+Uncomment (remove the leading '#' characters) the following 3 configuration lines:
+
+[org/gnome/login-screen]
+
+banner-message-enable=true
+banner-message-text='Welcome'
+
+Note: the lines are all near the bottom of the file but they are not adjacent to each other.
+
+Edit the banner-message-text='Welcome' line to contain the appropriate banner message text as shown below:
+
+banner-message-text='You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.\n\nBy using this IS (which includes any device attached to this IS), you consent to the following conditions:\n\n-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.\n\n-At any time, the USG may inspect and seize data stored on this IS.\n\n-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\n\n-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.\n\n-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details.'
+
+Note that it is similar to the text in /etc/issue but it is all on a single line and the newline characters have been replaced with \n.
+
+# sudo dconf update
+# sudo systemctl restart gdm3</fixtext><fix id="F-20891r304830_fix" /><check system="C-20892r304829_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system displays the Standard Mandatory DoD Notice and Consent Banner before granting access to the operating system via a graphical user logon.
+Note: If the system does not have Graphical User Interface installed, this requirement is Not Applicable.
+
+Check that the operating system displays the exact approved Standard Mandatory DoD Notice and Consent Banner text with the command:
+
+# grep banner-message-enable /etc/gdm3/greeter.dconf-defaults
+
+banner-message-enable=true
+
+If the line is commented out or set to "false", this is a finding.
+
+# grep banner-message-text /etc/gdm3/greeter.dconf-defaults
+
+banner-message-text="You are accessing a U.S. Government \(USG\) Information System \(IS\) that is provided for USG-authorized use only.\s+By using this IS \(which includes any device attached to this IS\), you consent to the following conditions:\s+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct \(PM\), law enforcement \(LE\), and counterintelligence \(CI\) investigations.\s+-At any time, the USG may inspect and seize data stored on this IS.\s+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.\s+-This IS includes security measures \(e.g., authentication and access controls\) to protect USG interests--not for your personal benefit or privacy.\s+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."
+
+If the banner-message-text is missing, commented out, or the text does not match the Standard Mandatory DoD Notice and Consent Banner exactly, this is a finding.</check-content></check></Rule></Group><Group id="V-219168"><title>SRG-OS-000109-GPOS-00056</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219168r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010036</version><title>The Ubuntu operating system must prevent direct login into the root account.</title><description>&lt;VulnDiscussion&gt;To assure individual accountability and prevent unauthorized access, organizational users must be individually identified and authenticated.
+
+A group authenticator is a generic account used by multiple individuals. Use of a group authenticator alone does not uniquely identify individual users. Examples of the group authenticator is the UNIX OS "root" user account, the Windows "Administrator" account, the "sa" account, or a "helpdesk" account.
+
+For example, the UNIX and Windows operating systems offer a 'switch user' capability allowing users to authenticate with their individual credentials and, when needed, 'switch' to the administrator role. This method provides for unique individual authentication prior to using a group authenticator.
+
+Users (and any processes acting on behalf of users) need to be uniquely identified and authenticated for all accesses other than those accesses explicitly identified and documented by the organization, which outlines specific user actions that can be performed on the operating system without identification or authentication.
+
+Requiring individuals to be authenticated with an individual authenticator prior to using a group authenticator allows for traceability of actions, as well as adding an additional level of protection of the actions that can be taken with group account knowledge.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109667</ident><ident system="http://cyber.mil/legacy">V-100563</ident><ident system="http://cyber.mil/cci">CCI-000770</ident><fixtext fixref="F-20892r304833_fix">Configure the Ubuntu operating system to prevent direct logins to the root account by performing the following operations:
+
+sudo passwd -l root</fixtext><fix id="F-20892r304833_fix" /><check system="C-20893r304832_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system prevents direct logins to the root account.
+
+Check that the Ubuntu operating system prevents direct logins to the root account with the following command:
+
+# sudo passwd -S root
+
+root L 11/11/2017 0 99999 7 -1
+
+If the output does not contain "L" in the second field to indicate the account is locked, this is a finding.</check-content></check></Rule></Group><Group id="V-219169"><title>SRG-OS-000134-GPOS-00068</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219169r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010037</version><title>The Ubuntu operating system must be configured so that only users who need access to security functions are part of the sudo group.</title><description>&lt;VulnDiscussion&gt;An isolation boundary provides access control and protects the integrity of the hardware, software, and firmware that perform security functions.
+
+Security functions are the hardware, software, and/or firmware of the information system responsible for enforcing the system security policy and supporting the isolation of code and data on which the protection is based. Operating systems implement code separation (i.e., separation of security functions from nonsecurity functions) in a number of ways, including through the provision of security kernels via processor rings or processor modes. For non-kernel code, security function isolation is often achieved through file system protections that serve to protect the code on disk and address space protections that protect executing code.
+
+Developers and implementers can increase the assurance in security functions by employing well-defined security policy models; structured, disciplined, and rigorous hardware and software development techniques; and sound system/security engineering principles. Implementation may include isolation of memory space and libraries. 
+
+The Ubuntu operating system restricts access to security functions through the use of access control mechanisms and by implementing least privilege capabilities.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109669</ident><ident system="http://cyber.mil/legacy">V-100565</ident><ident system="http://cyber.mil/cci">CCI-001084</ident><fixtext fixref="F-20893r304836_fix">Configure the sudo group with only members requiring access to security functions.
+
+To remove a user from the sudo group run:
+
+sudo gpasswd -d &lt;username&gt; sudo</fixtext><fix id="F-20893r304836_fix" /><check system="C-20894r304835_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the sudo group has only members who should have access to security functions. 
+
+# grep sudo /etc/group
+
+sudo:x:27:foo
+
+If the sudo group contains users not needing access to security functions, this is a finding.</check-content></check></Rule></Group><Group id="V-219170"><title>SRG-OS-000228-GPOS-00088</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219170r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010038</version><title>The Ubuntu operating system must display the Standard Mandatory DoD Notice and Consent Banner before granting any publically accessible connection to the system.</title><description>&lt;VulnDiscussion&gt;Display of a standardized and approved use notification before granting access to the Ubuntu operating system ensures privacy and security notification verbiage used is consistent with applicable federal laws, Executive Orders, directives, policies, regulations, standards, and guidance.
+
+System use notifications are required only for access via logon interfaces with human users and are not required when such human interfaces do not exist.
+
+The banner must be formatted in accordance with applicable DoD policy:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."
+
+Satisfies: SRG-OS-000228-GPOS-00088, SRG-OS-000023-GPOS-00006&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109671</ident><ident system="http://cyber.mil/legacy">V-100567</ident><ident system="http://cyber.mil/cci">CCI-001384</ident><ident system="http://cyber.mil/cci">CCI-001385</ident><ident system="http://cyber.mil/cci">CCI-001386</ident><ident system="http://cyber.mil/cci">CCI-001387</ident><ident system="http://cyber.mil/cci">CCI-001388</ident><ident system="http://cyber.mil/cci">CCI-000048</ident><fixtext fixref="F-20894r304839_fix">Configure the Ubuntu operating system to display the Standard Mandatory DoD Notice and Consent Banner before granting access to the system via SSH logon.
+
+Edit the SSH daemon configuration "/etc/ssh/sshd_config" file. Uncomment the banner keyword and configure it to point to the file that contains the correct banner. An example of this configure is below:
+
+Banner /etc/issue
+
+Either create the file containing the banner, or replace the text in the file with the Standard Mandatory DoD Notice and Consent Banner. The DoD required text is:
+
+"You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details."
+
+In order for the changes to take effect, the SSH daemon must be restarted.
+
+# sudo systemctl restart sshd.service</fixtext><fix id="F-20894r304839_fix" /><check system="C-20895r304838_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system displays the Standard Mandatory DoD Notice and Consent Banner before granting access to the Ubuntu operating system via a ssh logon.
+
+Check that the Ubuntu operating system displays the Standard Mandatory DoD Notice and Consent Banner before granting access to the Ubuntu operating system via a ssh logon with the following command:
+
+# grep -i banner /etc/ssh/sshd_config
+
+Banner /etc/issue
+
+The command will return the banner option along with the name of the file that contains the ssh banner. If the line is commented out, this is a finding.
+
+Check the specified banner file to check that it matches the Standard Mandatory DoD Notice and Consent Banner exactly:
+
+# cat /etc/issue
+
+“You are accessing a U.S. Government (USG) Information System (IS) that is provided for USG-authorized use only.
+
+By using this IS (which includes any device attached to this IS), you consent to the following conditions:
+
+-The USG routinely intercepts and monitors communications on this IS for purposes including, but not limited to, penetration testing, COMSEC monitoring, network operations and defense, personnel misconduct (PM), law enforcement (LE), and counterintelligence (CI) investigations.
+
+-At any time, the USG may inspect and seize data stored on this IS.
+
+-Communications using, or data stored on, this IS are not private, are subject to routine monitoring, interception, and search, and may be disclosed or used for any USG-authorized purpose.
+
+-This IS includes security measures (e.g., authentication and access controls) to protect USG interests--not for your personal benefit or privacy.
+
+-Notwithstanding the above, using this IS does not constitute consent to PM, LE or CI investigative searching or monitoring of the content of privileged communications, or work product, related to personal representation or services by attorneys, psychotherapists, or clergy, and their assistants. Such communications and work product are private and confidential. See User Agreement for details.”
+
+If the banner text does not match the Standard Mandatory DoD Notice and Consent Banner exactly, this is a finding.</check-content></check></Rule></Group><Group id="V-219172"><title>SRG-OS-000069-GPOS-00037</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219172r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010100</version><title>The Ubuntu operating system must enforce password complexity by requiring that at least one upper-case character be used.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
+
+Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109675</ident><ident system="http://cyber.mil/legacy">V-100571</ident><ident system="http://cyber.mil/cci">CCI-000192</ident><fixtext fixref="F-20896r304845_fix">Add or update the "/etc/security/pwquality.conf" file to contain the "ucredit" parameter:
+
+ucredit=-1</fixtext><fix id="F-20896r304845_fix" /><check system="C-20897r304844_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enforces password complexity by requiring that at least one upper-case character be used.
+
+Determine if the field "ucredit" is set in the "/etc/security/pwquality.conf" file with the following command:
+
+# grep -i "ucredit" /etc/security/pwquality.conf 
+ucredit=-1
+
+If the "ucredit" parameter is greater than "-1", or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219173"><title>SRG-OS-000070-GPOS-00038</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219173r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010101</version><title>The Ubuntu operating system must enforce password complexity by requiring that at least one lower-case character be used.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
+
+Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109677</ident><ident system="http://cyber.mil/legacy">V-100573</ident><ident system="http://cyber.mil/cci">CCI-000193</ident><fixtext fixref="F-20897r304848_fix">Add or update the "/etc/security/pwquality.conf" file to contain the "lcredit" parameter:
+
+lcredit=-1</fixtext><fix id="F-20897r304848_fix" /><check system="C-20898r304847_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enforces password complexity by requiring that at least one lower-case character be used.
+
+Determine if the field "lcredit" is set in the "/etc/security/pwquality.conf" file with the following command:
+
+# grep -i "lcredit" /etc/security/pwquality.conf 
+lcredit=-1
+
+If the "lcredit" parameter is greater than "-1", or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219174"><title>SRG-OS-000071-GPOS-00039</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219174r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010102</version><title>The Ubuntu operating system must enforce password complexity by requiring that at least one numeric character be used.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
+
+Password complexity is one factor of several that determines how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109679</ident><ident system="http://cyber.mil/legacy">V-100575</ident><ident system="http://cyber.mil/cci">CCI-000194</ident><fixtext fixref="F-20898r304851_fix">Configure the Ubuntu operating system to enforce password complexity by requiring that at least one numeric character be used.
+
+Add or update the "/etc/security/pwquality.conf" file to contain the "dcredit" parameter:
+
+dcredit=-1</fixtext><fix id="F-20898r304851_fix" /><check system="C-20899r304850_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system enforces password complexity by requiring that at least one numeric character be used.
+
+Determine if the field "dcredit" is set in the "/etc/security/pwquality.conf" file with the following command:
+
+# grep -i "dcredit" /etc/security/pwquality.conf 
+dcredit=-1
+
+If the "dcredit" parameter is greater than "-1", or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219175"><title>SRG-OS-000072-GPOS-00040</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219175r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010103</version><title>The Ubuntu operating system must require the change of at least 8 characters when passwords are changed.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system allows the user to consecutively reuse extensive portions of passwords, this increases the chances of password compromise by increasing the window of opportunity for attempts at guessing and brute-force attacks.
+
+The number of changed characters refers to the number of changes required with respect to the total number of positions in the current password. In other words, characters may be the same within the two passwords; however, the positions of the like characters must be different.
+
+If the password length is an odd number then number of changed characters must be rounded up. For example, a password length of 15 characters must require the change of at least 8 characters.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109681</ident><ident system="http://cyber.mil/legacy">V-100577</ident><ident system="http://cyber.mil/cci">CCI-000195</ident><fixtext fixref="F-20899r304854_fix">Configure the Ubuntu operating system to require the change of at least 8 characters when passwords are changed.
+
+Add or update the "/etc/security/pwquality.conf" file to include the "difok=8" parameter:
+
+difok=8</fixtext><fix id="F-20899r304854_fix" /><check system="C-20900r304853_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system requires the change of at least 8 characters when passwords are changed.
+
+Determine if the field "difok" is set in the "/etc/security/pwquality.conf" file with the following command:
+
+# grep -i "difok" /etc/security/pwquality.conf
+difok=8
+
+If the "difok" parameter is less than "8", or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219176"><title>SRG-OS-000073-GPOS-00041</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219176r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010104</version><title>The Ubuntu operating system must encrypt all stored passwords with a FIPS 140-2 approved cryptographic hashing algorithm.</title><description>&lt;VulnDiscussion&gt;Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109683</ident><ident system="http://cyber.mil/legacy">V-100579</ident><ident system="http://cyber.mil/cci">CCI-000196</ident><fixtext fixref="F-20900r304857_fix">Configure the Ubuntu operating system to encrypt all stored passwords. 
+
+Edit/Modify the following line in the "/etc/login.defs" file and set "ENCRYPT_METHOD" to SHA512.
+
+ENCRYPT_METHOD SHA512</fixtext><fix id="F-20900r304857_fix" /><check system="C-20901r304856_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the shadow password suite configuration is set to encrypt password with a FIPS 140-2 approved cryptographic hashing algorithm.
+
+Check the hashing algorithm that is being used to hash passwords with the following command:
+
+# cat /etc/login.defs | grep -i crypt
+
+ENCRYPT_METHOD SHA512
+
+If "ENCRYPT_METHOD" does not equal SHA512 or greater, this is a finding.</check-content></check></Rule></Group><Group id="V-219177"><title>SRG-OS-000074-GPOS-00042</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219177r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010105</version><title>The Ubuntu operating system must not have the telnet package installed.</title><description>&lt;VulnDiscussion&gt;Passwords need to be protected at all times, and encryption is the standard method for protecting passwords. If passwords are not encrypted, they can be plainly read (i.e., clear text) and easily compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109685</ident><ident system="http://cyber.mil/legacy">V-100581</ident><ident system="http://cyber.mil/cci">CCI-000197</ident><fixtext fixref="F-20901r304860_fix">Remove the telnet package from the Ubuntu operating system by running the following command:
+
+# sudo apt-get remove telnetd</fixtext><fix id="F-20901r304860_fix" /><check system="C-20902r304859_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the telnet package is not installed on the Ubuntu operating system.
+
+Check that the telnet daemon is not installed on the Ubuntu operating system by running the following command:
+
+# dpkg -l | grep telnetd
+
+If the package is installed, this is a finding.</check-content></check></Rule></Group><Group id="V-219178"><title>SRG-OS-000075-GPOS-00043</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219178r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010106</version><title>The Ubuntu operating system must enforce 24 hours/1 day as the minimum password lifetime. Passwords for new users must have a 24 hours/1 day minimum password lifetime restriction.</title><description>&lt;VulnDiscussion&gt;Enforcing a minimum password lifetime helps to prevent repeated password changes to defeat the password reuse or history enforcement requirement. If users are allowed to immediately and continually change their password, then the password could be repeatedly changed in a short period of time to defeat the organization's policy regarding password reuse.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109687</ident><ident system="http://cyber.mil/legacy">V-100583</ident><ident system="http://cyber.mil/cci">CCI-000198</ident><fixtext fixref="F-20902r304863_fix">Configure the Ubuntu operating system to enforce a 24 hours/1 day minimum password lifetime.
+
+Add, or modify the following line in the "/etc/login.defs" file:
+
+PASS_MIN_DAYS 1</fixtext><fix id="F-20902r304863_fix" /><check system="C-20903r304862_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system enforces a 24 hours/1 day minimum password lifetime for new user accounts by running the following command:
+
+# grep -i pass_min_days /etc/login.defs
+
+PASS_MIN_DAYS 1
+
+If the "PASS_MIN_DAYS" parameter value is less than 1, or commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219179"><title>SRG-OS-000076-GPOS-00044</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219179r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010107</version><title>The Ubuntu operating system must enforce a 60-day maximum password lifetime restriction. Passwords for new users must have a 60-day maximum password lifetime restriction.</title><description>&lt;VulnDiscussion&gt;Any password, no matter how complex, can eventually be cracked. Therefore, passwords need to be changed periodically. If the operating system does not limit the lifetime of passwords and force users to change their passwords, there is the risk that the operating system passwords could be compromised.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109689</ident><ident system="http://cyber.mil/legacy">V-100585</ident><ident system="http://cyber.mil/cci">CCI-000199</ident><fixtext fixref="F-20903r304866_fix">Configure the Ubuntu operating system to enforce a 60-day maximum password lifetime.
+
+Add, or modify the following line in the "/etc/login.defs" file:
+
+PASS_MAX_DAYS 60</fixtext><fix id="F-20903r304866_fix" /><check system="C-20904r304865_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system enforces a 60-day maximum password lifetime for new user accounts by running the following command:
+
+# grep -i pass_max_days /etc/login.defs
+PASS_MAX_DAYS 60
+
+If the "PASS_MAX_DAYS" parameter value is less than 60, or commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219180"><title>SRG-OS-000077-GPOS-00045</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219180r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010108</version><title>The Ubuntu operating system must prohibit password reuse for a minimum of five generations.</title><description>&lt;VulnDiscussion&gt;Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. If the information system or application allows the user to consecutively reuse their password when that password has exceeded its defined lifetime, the end result is a password that is not changed as per policy requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109691</ident><ident system="http://cyber.mil/legacy">V-100587</ident><ident system="http://cyber.mil/cci">CCI-000200</ident><fixtext fixref="F-20904r304869_fix">Configure the Ubuntu operating system prevents passwords from being reused for a minimum of five generations.
+
+Add, or modify the "remember" parameter value to the following line in "/etc/pam.d/common-password" file:
+
+password [success=1 default=ignore] pam_unix.so sha512 shadow remember=5 rounds=5000</fixtext><fix id="F-20904r304869_fix" /><check system="C-20905r304868_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system prevents passwords from being reused for a minimum of five generations by running the following command:
+
+# grep -i remember /etc/pam.d/common-password
+
+password [success=1 default=ignore] pam_unix.so sha512 shadow remember=5 rounds=5000
+
+If the "remember" parameter value is not greater than or equal to 5, commented out, or not set at all this is a finding.</check-content></check></Rule></Group><Group id="V-219181"><title>SRG-OS-000078-GPOS-00046</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219181r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010109</version><title>The Ubuntu operating system must enforce a minimum 15-character password length.</title><description>&lt;VulnDiscussion&gt;The shorter the password, the lower the number of possible combinations that need to be tested before the password is compromised.
+
+Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. Password length is one factor of several that helps to determine strength and how long it takes to crack a password. Use of more characters in a password helps to exponentially increase the time and/or resources required to compromise the password.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109693</ident><ident system="http://cyber.mil/legacy">V-100589</ident><ident system="http://cyber.mil/cci">CCI-000205</ident><fixtext fixref="F-20905r304872_fix">Configure the Ubuntu operating system to enforce a minimum 15-character password length.
+
+Add, or modify the "minlen" parameter value to the "/etc/security/pwquality.conf" file:
+
+minlen=15</fixtext><fix id="F-20905r304872_fix" /><check system="C-20906r304871_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the pwquality configuration file enforces a minimum 15-character password length, by running the following command:
+
+# grep -i minlen /etc/security/pwquality.conf
+ minlen=15
+
+If "minlen" parameter value is not 15 or higher, or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219182"><title>SRG-OS-000120-GPOS-00061</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219182r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010110</version><title>The Ubuntu operating system must employ a FIPS 140-2 approved cryptographic hashing algorithms for all created and stored passwords.</title><description>&lt;VulnDiscussion&gt;The Ubuntu operating system must use a FIPS-compliant hashing algorithm to securely store the password. The FIPS-compliant hashing algorithm parameters must be selected in order to harden the system against offline attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109695</ident><ident system="http://cyber.mil/legacy">V-100591</ident><ident system="http://cyber.mil/cci">CCI-000803</ident><fixtext fixref="F-20906r304875_fix">Configure the Ubuntu operating system to encrypt all stored passwords with a strong cryptographic hash.
+
+Edit/modify the following line in the file "/etc/pam.d/common-password" file to include the sha512 option for pam_unix.so:
+
+password [success=1 default=ignore] pam_unix.so obscure sha512
+
+Edit/modify /etc/login.defs and set "ENCRYPT_METHOD sha512".</fixtext><fix id="F-20906r304875_fix" /><check system="C-20907r304874_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that encrypted passwords stored in /etc/shadow use a strong cryptographic hash.
+
+Check that pam_unix.so auth is configured to use sha512 with the following command:
+
+# grep password /etc/pam.d/common-password | grep pam_unix
+
+password [success=1 default=ignore] pam_unix.so obscure sha512
+
+If "sha512" is not an option of the output, or is commented out, this is a finding.
+
+Check that ENCRYPT_METHOD is set to sha512 in /etc/login.defs:
+
+# grep -i ENCRYPT_METHOD /etc/login.defs
+
+ENCRYPT_METHOD SHA512
+
+If the output does not contain "sha512", or it is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219183"><title>SRG-OS-000380-GPOS-00165</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219183r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010112</version><title>The Ubuntu operating system must allow the use of a temporary password for system logons with an immediate change to a permanent password.</title><description>&lt;VulnDiscussion&gt;Without providing this capability, an account may be created without a password. Non-repudiation cannot be guaranteed once an account is created if a user is not forced to change the temporary password upon initial logon.
+
+Temporary passwords are typically used to allow access when new accounts are created or passwords are changed. It is common practice for administrators to create temporary passwords for user accounts which allow the users to log on, yet force them to change the password once they have successfully authenticated.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109697</ident><ident system="http://cyber.mil/legacy">V-100593</ident><ident system="http://cyber.mil/cci">CCI-002041</ident><fixtext fixref="F-20907r304878_fix">Create a policy that ensures when a user is created, it is created using a method that forces a user to change their password upon their next login.
+
+Below are two examples of how to create a user account that requires the user to change their password upon their next login.
+
+# chage -d 0 [UserName]
+
+or 
+
+# passwd -e [UserName]</fixtext><fix id="F-20907r304878_fix" /><check system="C-20908r304877_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify a policy exists that ensures when a user account is created, it is created using a method that forces a user to change their password upon their next login.
+
+If a policy does not exist, this is a finding.</check-content></check></Rule></Group><Group id="V-219184"><title>SRG-OS-000480-GPOS-00225</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219184r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010113</version><title>The Ubuntu operating system must prevent the use of dictionary words for passwords.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system allows the user to select passwords based on dictionary words, then this increases the chances of password compromise by increasing the opportunity for successful guesses and brute-force attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109699</ident><ident system="http://cyber.mil/legacy">V-100595</ident><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-20908r304881_fix">Configure the Ubuntu operating system to prevent the use of dictionary words for passwords.
+
+Add or update the following line in the "/etc/security/pwquality.conf" file to include the "dictcheck=1" parameter:
+
+dictcheck=1</fixtext><fix id="F-20908r304881_fix" /><check system="C-20909r304880_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system uses the cracklib library to prevent the use of dictionary words with the following command:
+
+# grep dictcheck /etc/security/pwquality.conf
+
+dictcheck=1
+
+If the "dictcheck" parameter is not set to "1", or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219185"><title>SRG-OS-000373-GPOS-00156</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219185r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010114</version><title>The Ubuntu operating system must require users to re-authenticate for privilege escalation and changing roles.</title><description>&lt;VulnDiscussion&gt;Without re-authentication, users may access resources or perform tasks for which they do not have authorization. 
+
+When the Ubuntu operating system provides the capability to escalate a functional capability or change security roles, it is critical the user re-authenticate.
+
+Satisfies: SRG-OS-000373-GPOS-00156, SRG-OS-000373-GPOS-00157&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109701</ident><ident system="http://cyber.mil/legacy">V-100597</ident><ident system="http://cyber.mil/cci">CCI-002038</ident><fixtext fixref="F-20909r304884_fix">Remove any occurrence of "NOPASSWD" or "!authenticate" found in "/etc/sudoers" file or files in the /etc/sudoers.d directory.</fixtext><fix id="F-20909r304884_fix" /><check system="C-20910r304883_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that "/etc/sudoers" has no occurrences of "NOPASSWD" or "!authenticate".
+
+Check that the "/etc/sudoers" file has no occurrences of "NOPASSWD" or "!authenticate" by running the following command:
+
+# sudo egrep -i '(nopasswd|!authenticate)' /etc/sudoers /etc/sudoers.d/*
+
+If any occurrences of "NOPASSWD" or "!authenticate" return from the command, this is a finding.</check-content></check></Rule></Group><Group id="V-219186"><title>SRG-OS-000480-GPOS-00225</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219186r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010116</version><title>The Ubuntu Operating system must be configured so that when passwords are changed or new passwords are established, pwquality must be used.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity, or strength, is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks. "pwquality" enforces complex password construction configuration and has the ability to limit brute-force attacks on the system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109703</ident><ident system="http://cyber.mil/legacy">V-100599</ident><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-20910r569488_fix">Configure the operating system to use "pwquality" to enforce password complexity rules.
+
+Install the pam_pwquality package by using the following command:
+
+# apt-get install libpam-pwquality -y
+
+Add the following line to "/etc/security/pwquality.conf" (or modify the line to have the required value):
+
+enforcing = 1
+
+Add the following line to "/etc/pam.d/common-password" (or modify the line to have the required value):
+
+password requisite pam_pwquality.so retry=3 enforce_for_root
+
+Note: The value of "retry" should be between "1" and "3".</fixtext><fix id="F-20910r569488_fix" /><check system="C-20911r569487_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system has the libpam-pwquality package installed, by running the following command:
+
+# dpkg -l libpam-pwquality
+
+ii libpam-pwquality:amd64 1.4.0-2 amd64 PAM module to check password strength
+
+If "libpam-pwquality" is not installed, this is a finding.
+
+Verify the operating system uses "pwquality" to enforce the password complexity rules. 
+
+Verify the pwquality module is being enforced by the Ubuntu Operating System, by running the following command:
+
+# grep -i enforcing /etc/security/pwquality.conf
+
+enforcing = 1
+
+If the value of "enforcing" is not 1 or the line is commented out, this is a finding.
+
+Check for the use of "pwquality" with the following command:
+
+# sudo cat /etc/pam.d/common-password | grep requisite | grep pam_pwquality
+
+password requisite pam_pwquality.so retry=3 enforce_for_root
+
+If no output is returned or the line is commented out, this is a finding.
+If the value of "retry" is set to "0" or greater than "3", this is a finding.
+If "enforce_for_root" is missing from the configuration line, this is a finding.</check-content></check></Rule></Group><Group id="V-219187"><title>SRG-OS-000138-GPOS-00069</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219187r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010120</version><title>The Ubuntu operating system must set a sticky bit on all public directories to prevent unauthorized and unintended information transferred via shared system resources.</title><description>&lt;VulnDiscussion&gt;Preventing unauthorized information transfers mitigates the risk of information, including encrypted representations of information, produced by the actions of prior users/roles (or the actions of processes acting on behalf of prior users/roles) from being available to any current users/roles (or current processes) that obtain access to shared system resources (e.g., registers, main memory, hard disks) after those resources have been released back to information systems. The control of information in shared resources is also commonly referred to as object reuse and residual information protection.
+
+This requirement generally applies to the design of an information technology product, but it can also apply to the configuration of particular information system components that are, or use, such products. This can be verified by acceptance/validation processes in DoD or other government agencies.
+
+There may be shared resources with configurable protections (e.g., files in storage) that may be assessed on specific information system components.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109705</ident><ident system="http://cyber.mil/legacy">V-100601</ident><ident system="http://cyber.mil/cci">CCI-001090</ident><fixtext fixref="F-20911r304890_fix">Configure all public directories to have the sticky bit set to prevent unauthorized and unintended information transferred via shared system resources.
+
+Set the sticky bit on all public directories using the command, replace "[Public Directory]" with any directory path missing the sticky bit:
+
+# sudo chmod +t [Public Directory]</fixtext><fix id="F-20911r304890_fix" /><check system="C-20912r304889_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that all public (world writeable) directories have the public sticky bit set.
+
+Find world-writable directories that lack the sticky bit by running the following command: 
+
+# sudo find / -type d -perm -002 ! -perm -1000
+
+If any world-writable directories are found missing the sticky bit, this is a finding.</check-content></check></Rule></Group><Group id="V-219188"><title>SRG-OS-000205-GPOS-00083</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219188r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010121</version><title>The Ubuntu operating system must generate error messages that provide information necessary for corrective actions without revealing information that could be exploited by adversaries.</title><description>&lt;VulnDiscussion&gt;Any operating system providing too much information in error messages risks compromising the data and security of the structure, and content of error messages needs to be carefully considered by the organization.
+
+Organizations carefully consider the structure/content of error messages. The extent to which information systems are able to identify and handle error conditions is guided by organizational policy and operational requirements. Information that could be exploited by adversaries includes, for example, erroneous logon attempts with passwords entered by mistake as the username, mission/business information that can be derived from (if not stated explicitly by) information recorded, and personal information, such as account numbers, social security numbers, and credit card numbers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109707</ident><ident system="http://cyber.mil/legacy">V-100603</ident><ident system="http://cyber.mil/cci">CCI-001312</ident><fixtext fixref="F-20912r304893_fix">Configured the Ubuntu operating system to set permissions of all log files under /var/log directory to 640 or more restricted, by using the following command:
+
+# sudo find /var/log -perm /137 -type f -exec chmod 640 '{}' \;</fixtext><fix id="F-20912r304893_fix" /><check system="C-20913r304892_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system has all system log files under the /var/log directory with a permission set to 640, by using the following command:
+
+# sudo find /var/log -perm /137 -type f -exec stat -c "%n %a" {} \; 
+
+If command displays any output, this is a finding.</check-content></check></Rule></Group><Group id="V-219189"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219189r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010122</version><title>The Ubuntu operating system must configure the /var/log directory to be group-owned by syslog.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
+
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109709</ident><ident system="http://cyber.mil/legacy">V-100605</ident><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-20913r304896_fix">Configure the Ubuntu operating system to have syslog group-own the /var/log directory by running the following command:
+
+# sudo chgrp syslog /var/log</fixtext><fix id="F-20913r304896_fix" /><check system="C-20914r304895_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system configures the /var/log directory to be group-owned by syslog.
+
+Check that the /var/log directory is group owned by syslog with the following command:
+
+# sudo stat -c "%n %G" /var/log
+/var/log syslog
+
+If the /var/log directory is not group-owned by syslog, this is a finding.</check-content></check></Rule></Group><Group id="V-219190"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219190r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010123</version><title>The Ubuntu operating system must configure the /var/log directory to be owned by root.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
+
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109711</ident><ident system="http://cyber.mil/legacy">V-100607</ident><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-20914r304899_fix">Configure the Ubuntu operating system to have root own the /var/log directory by running the following command:
+
+# sudo chown root /var/log</fixtext><fix id="F-20914r304899_fix" /><check system="C-20915r304898_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system configures the /var/log directory to be owned by root.
+
+Check that the /var/log directory is owned by root with the following command:
+
+# sudo stat -c "%n %U" /var/log
+/var/log root
+
+If the /var/log directory is not owned by root, this is a finding.</check-content></check></Rule></Group><Group id="V-219191"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219191r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010124</version><title>The Ubuntu operating system must configure the /var/log directory to have mode 0750 or less permissive.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
+
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109713</ident><ident system="http://cyber.mil/legacy">V-100609</ident><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-20915r304902_fix">Configure the Ubuntu operating system to have permissions of 0750 for the /var/log directory by running the following command:
+
+# sudo chmod 0750 /var/log</fixtext><fix id="F-20915r304902_fix" /><check system="C-20916r304901_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system configures the /var/log directory with a mode of 750 or less permissive.
+
+Check the mode of the /var/log directory with the following command:
+
+# stat -c "%n %a" /var/log
+
+/var/log 750
+
+If a value of "750" or less permissive is not returned, this is a finding.</check-content></check></Rule></Group><Group id="V-219192"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219192r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010125</version><title>The Ubuntu operating system must configure the /var/log/syslog file to be group-owned by adm.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
+
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109715</ident><ident system="http://cyber.mil/legacy">V-100611</ident><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-20916r304905_fix">Configure the Ubuntu operating system to have adm group-own the /var/log/syslog file by running the following command:
+
+# sudo chgrp adm /var/log/syslog</fixtext><fix id="F-20916r304905_fix" /><check system="C-20917r304904_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system configures the /var/log/syslog file to be group-owned by adm.
+
+Check that the /var/log/syslog file is group-owned by adm with the following command:
+
+# sudo stat -c "%n %G" /var/log/syslog
+/var/log/syslog adm
+
+If the /var/log/syslog file is not group-owned by adm, this is a finding.</check-content></check></Rule></Group><Group id="V-219193"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219193r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010126</version><title>The Ubuntu operating system must configure /var/log/syslog file to be owned by syslog.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
+
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109717</ident><ident system="http://cyber.mil/legacy">V-100613</ident><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-20917r304908_fix">Configure the Ubuntu operating system to have syslog own the /var/log/syslog file by running the following command:
+
+# sudo chown syslog /var/log/syslog</fixtext><fix id="F-20917r304908_fix" /><check system="C-20918r304907_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system configures the /var/log/syslog file to be owned by syslog.
+
+Check that the /var/log/syslog file is owned by syslog with the following command:
+
+# sudo stat -c "%n %U" /var/log/syslog
+/var/log/syslog syslog
+
+If the /var/log/syslog file is not owned by syslog, this is a finding.</check-content></check></Rule></Group><Group id="V-219194"><title>SRG-OS-000206-GPOS-00084</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219194r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010127</version><title>The Ubuntu operating system must configure /var/log/syslog file with mode 0640 or less permissive.</title><description>&lt;VulnDiscussion&gt;Only authorized personnel should be aware of errors and the details of the errors. Error messages are an indicator of an organization's operational state or can identify the operating system or platform. Additionally, Personally Identifiable Information (PII) and operational information must not be revealed through error messages to unauthorized personnel or their designated representatives.
+
+The structure and content of error messages must be carefully considered by the organization and development team. The extent to which the information system is able to identify and handle error conditions is guided by organizational policy and operational requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109719</ident><ident system="http://cyber.mil/legacy">V-100615</ident><ident system="http://cyber.mil/cci">CCI-001314</ident><fixtext fixref="F-20918r304911_fix">Configure the Ubuntu operating system to have permissions of 0640 o for the /var/log/syslog file by running the following command:
+
+# sudo chmod 0640 /var/log/syslog</fixtext><fix id="F-20918r304911_fix" /><check system="C-20919r304910_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system configures the /var/log/syslog file with mode 0640 or less permissive.
+
+Check the /var/log/syslog permissions by running the following command:
+
+# stat -c "%n %a" /var/log/syslog
+
+/var/log/syslog 640
+
+If a value of "640" or less permissive is not returned, this is a finding.</check-content></check></Rule></Group><Group id="V-219195"><title>SRG-OS-000256-GPOS-00097</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219195r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010128</version><title>The Ubuntu operating system must configure audit tools with a mode of 0755 or less permissive.</title><description>&lt;VulnDiscussion&gt;Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information.
+
+The Ubuntu operating system providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user enjoys in order to make access decisions regarding the access to audit tools.
+
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.
+
+Satisfies: SRG-OS-000256-GPOS-00097, SRG-OS-000257-GPOS-00098, SRG-OS-000258-GPOS-00099&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109721</ident><ident system="http://cyber.mil/legacy">V-100617</ident><ident system="http://cyber.mil/cci">CCI-001494</ident><ident system="http://cyber.mil/cci">CCI-001495</ident><ident system="http://cyber.mil/cci">CCI-001493</ident><fixtext fixref="F-20919r304914_fix">Configure the audit tools on the Ubuntu operating system to be protected from unauthorized access by setting the correct permissive mode using the following command:
+
+# sudo chmod 0755 [audit_tool]
+
+Replace "[audit_tool]" with the audit tool that does not have the correct permissive mode.</fixtext><fix id="F-20919r304914_fix" /><check system="C-20920r304913_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the audit tools are protected from unauthorized access, deletion, or modification by checking the permissive mode.
+
+For each audit tool,
+/sbin/auditctl, /sbin/aureport, /sbin/ausearch, /sbin/autrace, /sbin/auditd, /sbin/audispd, /sbin/augenrules 
+
+Check the permissions by running the following command:
+
+# stat -c "%n %a" /sbin/auditctl
+
+755 /sbin/auditctl
+
+If any of the audit tools have a mode more permissive than 0755, this is a finding.</check-content></check></Rule></Group><Group id="V-219196"><title>SRG-OS-000256-GPOS-00097</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219196r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010129</version><title>The Ubuntu operating system must configure audit tools to be owned by root.</title><description>&lt;VulnDiscussion&gt;Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information.
+
+The Ubuntu operating system providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user enjoys in order to make access decisions regarding the access to audit tools.
+
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109723</ident><ident system="http://cyber.mil/legacy">V-100619</ident><ident system="http://cyber.mil/cci">CCI-001493</ident><fixtext fixref="F-20920r304917_fix">Configure the audit tools on the Ubuntu operating system to be owned by root, by running the following command:
+
+# sudo chown root [audit_tool]
+
+Replace "[audit_tool]" with each audit tool not owned by root.</fixtext><fix id="F-20920r304917_fix" /><check system="C-20921r304916_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system configures the audit tools to be owned by root to prevent any unauthorized access, deletion, or modification.
+
+For each audit tool, 
+/sbin/auditctl, /sbin/aureport, /sbin/ausearch, /sbin/autrace, /sbin/auditd, /sbin/audispd, /sbin/augenrules 
+
+Check the ownership by running the following command:
+
+# stat -c "%n %U" /sbin/auditctl
+
+/sbin/auditctl root
+
+If any of the audit tools are not owned by root, this is a finding.</check-content></check></Rule></Group><Group id="V-219197"><title>SRG-OS-000256-GPOS-00097</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219197r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010130</version><title>The Ubuntu operating system must configure the audit tools to be group-owned by root.</title><description>&lt;VulnDiscussion&gt;Protecting audit information also includes identifying and protecting the tools used to view and manipulate log data. Therefore, protecting audit tools is necessary to prevent unauthorized operation on audit information.
+
+The Ubuntu operating system providing tools to interface with audit information will leverage user permissions and roles identifying the user accessing the tools and the corresponding rights the user enjoys in order to make access decisions regarding the access to audit tools.
+
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109725</ident><ident system="http://cyber.mil/legacy">V-100621</ident><ident system="http://cyber.mil/cci">CCI-001493</ident><fixtext fixref="F-20921r304920_fix">Configure the audit tools on the Ubuntu operating system to be group-owned by root, by running the following command:
+
+# sudo chgrp root [audit_tool]
+
+Replace "[audit_tool]" with each audit tool not group-owned by root.</fixtext><fix id="F-20921r304920_fix" /><check system="C-20922r304919_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system configures the audit tools to be group-owned by root to prevent any unauthorized access, deletion, or modification.
+
+For each audit tools, 
+/sbin/auditctl, /sbin/aureport, /sbin/ausearch, /sbin/autrace, /sbin/auditd, /sbin/audispd, /sbin/augenrules 
+
+Check the group-owner of each audit tool by running the following commands:
+
+stat -c "%n %G" /sbin/auditctl
+
+/sbin/auditctl root
+
+If any of the audit tools are not group-owned by root, this is a finding.</check-content></check></Rule></Group><Group id="V-219198"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219198r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010133</version><title>The Ubuntu operating system library files must have mode 0755 or less permissive.</title><description>&lt;VulnDiscussion&gt;If the operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109727</ident><ident system="http://cyber.mil/legacy">V-100623</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20922r304923_fix">Configure the library files to be protected from unauthorized access. Run the following command:
+
+# sudo find /lib /lib64 /usr/lib -perm /022 -type f -exec chmod 755 '{}' \;</fixtext><fix id="F-20922r304923_fix" /><check system="C-20923r304922_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide shared library files contained in the directories "/lib", "/lib64" and "/usr/lib" have mode 0755 or less permissive.
+
+Check that the system-wide shared library files have mode 0755 or less permissive with the following command:
+
+# sudo find /lib /lib64 /usr/lib -perm /022 -type f -exec stat -c "%n %a" '{}' \;
+/usr/lib64/pkcs11-spy.so
+
+If any files are found to be group-writable or world-writable, this is a finding.</check-content></check></Rule></Group><Group id="V-219199"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219199r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010134</version><title>The Ubuntu operating system library directories must have mode 0755 or less permissive.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109729</ident><ident system="http://cyber.mil/legacy">V-100625</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20923r569490_fix">Configure the shared library directories to be protected from unauthorized access. Run the following command:
+
+# sudo find /lib /lib64 /usr/lib -perm /022 -type d -exec chmod 755 '{}' \;</fixtext><fix id="F-20923r569490_fix" /><check system="C-20924r569465_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide shared library directories "/lib", "/lib64" and "/usr/lib have mode 0755 or less permissive.
+
+Check that the system-wide shared library directories have mode 0755 or less permissive with the following command:
+
+# sudo find /lib /lib64 /usr/lib -perm /022 -type d -exec stat -c "%n %a" '{}' \;
+
+If any of the aforementioned directories are found to be group-writable or world-writable, this is a finding.</check-content></check></Rule></Group><Group id="V-219200"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219200r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010135</version><title>The Ubuntu operating system library files must be owned by root.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109731</ident><ident system="http://cyber.mil/legacy">V-100627</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20924r304929_fix">Configure the system library files to be protected from unauthorized access. Run the following command:
+
+# sudo find /lib /usr/lib /lib64 ! -user root -type f -exec chown root '{}' \;</fixtext><fix id="F-20924r304929_fix" /><check system="C-20925r304928_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide shared library files contained in the directories "/lib", "/lib64" and "/usr/lib" are owned by root.
+
+Check that the system-wide shared library files are owned by root with the following command:
+
+# sudo find /lib /usr/lib /lib64 ! -user root -type f -exec stat -c "%n %U" '{}' \;
+
+If any system wide library file is returned, this is a finding.</check-content></check></Rule></Group><Group id="V-219201"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219201r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010136</version><title>The Ubuntu operating system library directories must be owned by root.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109733</ident><ident system="http://cyber.mil/legacy">V-100629</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20925r304932_fix">Configure the library files and their respective parent directories to be protected from unauthorized access. Run the following command:
+
+# sudo find /lib /usr/lib /lib64 ! -user root -type d -exec chown root '{}' \;</fixtext><fix id="F-20925r304932_fix" /><check system="C-20926r304931_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide shared library directories "/lib", "/lib64" and "/usr/lib" are owned by root.
+
+Check that the system-wide shared library directories are owned by root with the following command:
+
+# sudo find /lib /usr/lib /lib64 ! -user root -type d -exec stat -c "%n %U" '{}' \;
+
+If any system wide library directory is returned, this is a finding.</check-content></check></Rule></Group><Group id="V-219202"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219202r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010137</version><title>The Ubuntu operating system library files must be group-owned by root.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109735</ident><ident system="http://cyber.mil/legacy">V-100631</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20926r304935_fix">Configure the system library files to be protected from unauthorized access. Run the following command:
+
+# sudo find /lib /usr/lib /lib64 ! -group root -type f -exec chgrp root '{}' \;</fixtext><fix id="F-20926r304935_fix" /><check system="C-20927r304934_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide library files contained in the directories "/lib", "/lib64" and "/usr/lib" are group-owned by root.
+
+Check that the system-wide library files are group-owned by root with the following command:
+
+# sudo find /lib /usr/lib /lib64 ! -group root -type f -exec stat -c "%n %G" '{}' \;
+
+If any system wide shared library file is returned, this is a finding.</check-content></check></Rule></Group><Group id="V-219203"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219203r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010138</version><title>The Ubuntu operating system library directories must be group-owned by root.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109737</ident><ident system="http://cyber.mil/legacy">V-100633</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20927r304938_fix">Configure the system library directories to be protected from unauthorized access. Run the following command:
+
+# sudo find /lib /usr/lib /lib64 ! -group root -type d -exec chgrp root '{}' \;</fixtext><fix id="F-20927r304938_fix" /><check system="C-20928r304937_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system-wide library directories "/lib", "/lib64" and "/usr/lib" are group-owned by root.
+
+Check that the system-wide library directories are group-owned by root with the following command:
+
+# sudo find /lib /usr/lib /lib64 ! -group root -type d -exec stat -c "%n %G" '{}' \;
+
+If any system wide shared library directory is returned, this is a finding.</check-content></check></Rule></Group><Group id="V-219204"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219204r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010139</version><title>The Ubuntu operating system must have system commands set to a mode of 0755 or less permissive.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109739</ident><ident system="http://cyber.mil/legacy">V-100635</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20928r304941_fix">Configure the system commands to be protected from unauthorized access. Run the following command:
+
+# sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin -perm /022 -type f -exec chmod 755 '{}' \;</fixtext><fix id="F-20928r304941_fix" /><check system="C-20929r304940_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands contained in the following directories have mode 0755 or less permissive:
+
+/bin
+/sbin
+/usr/bin
+/usr/sbin
+/usr/local/bin
+/usr/local/sbin
+
+Check that the system command files have mode 0755 or less permissive with the following command:
+
+# find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin -perm /022 -type f -exec stat -c "%n %a" '{}' \;
+
+If any files are found to be group-writable or world-writable, this is a finding.</check-content></check></Rule></Group><Group id="V-219205"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219205r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010140</version><title>The Ubuntu operating system must have directories that contain system commands set to a mode of 0755 or less permissive.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109741</ident><ident system="http://cyber.mil/legacy">V-100637</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20929r304944_fix">Configure the system commands directories to be protected from unauthorized access. Run the following command:
+
+# sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin -perm /022 -type d -exec chmod -R 755 '{}' \;</fixtext><fix id="F-20929r304944_fix" /><check system="C-20930r304943_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands directories have mode 0755 or less permissive:
+
+/bin
+/sbin
+/usr/bin
+/usr/sbin
+/usr/local/bin
+/usr/local/sbin
+
+Check that the system command directories have mode 0755 or less permissive with the following command:
+
+# find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin -perm /022 -type d -exec stat -c "%n %a" '{}' \;
+
+If any directories are found to be group-writable or world-writable, this is a finding.</check-content></check></Rule></Group><Group id="V-219206"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219206r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010141</version><title>The Ubuntu operating system must have system commands owned by root.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109743</ident><ident system="http://cyber.mil/legacy">V-100639</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20930r304947_fix">Configure the system commands - and their respective parent directories - to be protected from unauthorized access. Run the following command:
+
+# sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -user root -type f -exec chown root '{}' \;</fixtext><fix id="F-20930r304947_fix" /><check system="C-20931r304946_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands contained in the following directories are owned by root:
+
+/bin
+/sbin
+/usr/bin
+/usr/sbin
+/usr/local/bin
+/usr/local/sbin
+
+Use the following command for the check:
+
+# sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -user root -type f -exec stat -c "%n %U" '{}' \;
+
+If any system commands are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-219207"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219207r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010142</version><title>The Ubuntu operating system must have directories that contain system commands owned by root.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109745</ident><ident system="http://cyber.mil/legacy">V-100641</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20931r304950_fix">Configure the system commands directories to be protected from unauthorized access. Run the following command:
+
+# sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -user root -type d -exec chown root '{}' \;</fixtext><fix id="F-20931r304950_fix" /><check system="C-20932r304949_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands directories are owned by root:
+
+/bin
+/sbin
+/usr/bin
+/usr/sbin
+/usr/local/bin
+/usr/local/sbin
+
+Use the following command for the check:
+
+# sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -user root -type d -exec stat -c "%n %U" '{}' \;
+
+If any system commands directories are returned, this is a finding.</check-content></check></Rule></Group><Group id="V-219208"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219208r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010143</version><title>The Ubuntu operating system must have system commands group-owned by root.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109747</ident><ident system="http://cyber.mil/legacy">V-100643</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20932r304953_fix">Configure the system commands to be protected from unauthorized access. Run the following command:
+
+# sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -group root -type f -exec chgrp root '{}' \;</fixtext><fix id="F-20932r304953_fix" /><check system="C-20933r304952_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands contained in the following directories are group-owned by root:
+
+/bin
+/sbin
+/usr/bin
+/usr/sbin
+/usr/local/bin
+/usr/local/sbin
+
+Run the check with the following command:
+
+# sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -group root -type f -exec stat -c "%n %G" '{}' \;
+
+If any system commands are returned that are not Set Group ID up on execution (SGID) files and owned by a privileged account, this is a finding.</check-content></check></Rule></Group><Group id="V-219209"><title>SRG-OS-000259-GPOS-00100</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219209r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010144</version><title>The Ubuntu operating system must have directories that contain system commands group-owned by root.</title><description>&lt;VulnDiscussion&gt;If the Ubuntu operating system were to allow any user to make changes to software libraries, then those changes might be implemented without undergoing the appropriate testing and approvals that are part of a robust change management process.
+
+This requirement applies to Ubuntu operating systems with software libraries that are accessible and configurable, as in the case of interpreted languages. Software libraries also include privileged programs which execute with escalated privileges. Only qualified and authorized individuals must be allowed to obtain access to information system components for purposes of initiating changes, including upgrades and modifications.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109749</ident><ident system="http://cyber.mil/legacy">V-100645</ident><ident system="http://cyber.mil/cci">CCI-001499</ident><fixtext fixref="F-20933r304956_fix">Configure the system commands directories to be protected from unauthorized access. Run the following command:
+
+# sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -group root -type d -exec chgrp root '{}' \;</fixtext><fix id="F-20933r304956_fix" /><check system="C-20934r304955_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the system commands directories are group-owned by root:
+
+/bin
+/sbin
+/usr/bin
+/usr/sbin
+/usr/local/bin
+/usr/local/sbin
+
+Run the check with the following command:
+
+# sudo find -L /bin /sbin /usr/bin /usr/sbin /usr/local/bin /usr/local/sbin ! -group root -type d -exec stat -c "%n %G" '{}' \;
+
+If any system commands directories are returned that are not Set Group ID up on execution (SGID) files and owned by a privileged account, this is a finding.</check-content></check></Rule></Group><Group id="V-219210"><title>SRG-OS-000266-GPOS-00101</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219210r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010145</version><title>The Ubuntu operating system must enforce password complexity by requiring that at least one special character be used.</title><description>&lt;VulnDiscussion&gt;Use of a complex password helps to increase the time and resources required to compromise the password. Password complexity or strength is a measure of the effectiveness of a password in resisting attempts at guessing and brute-force attacks.
+
+Password complexity is one factor in determining how long it takes to crack a password. The more complex the password, the greater the number of possible combinations that need to be tested before the password is compromised.
+
+Special characters are those characters that are not alphanumeric. Examples include: ~ ! @ # $ % ^ *.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109751</ident><ident system="http://cyber.mil/legacy">V-100647</ident><ident system="http://cyber.mil/cci">CCI-001619</ident><fixtext fixref="F-20934r304959_fix">Configure the Ubuntu operating system to enforce password complexity by requiring that at least one special character be used. 
+
+Add or update the following line in the "/etc/security/pwquality.conf" file to include the "ocredit=-1" parameter:
+
+ocredit=-1</fixtext><fix id="F-20934r304959_fix" /><check system="C-20935r304958_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Determine if the field "ocredit" is set in the "/etc/security/pwquality.conf" file with the following command:
+
+# grep -i "ocredit" /etc/security/pwquality.conf 
+ocredit=-1
+
+If the "ocredit" parameter is greater than "-1", or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219211"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219211r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010150</version><title>The Ubuntu Operating system must disable the x86 Ctrl-Alt-Delete key sequence if a graphical user interface is installed.</title><description>&lt;VulnDiscussion&gt;A locally logged-on user who presses Ctrl-Alt-Delete, when at the console, can reboot the system. If accidentally pressed, as could happen in the case of a mixed OS environment, this can create the risk of short-term loss of availability of systems due to unintentional reboot. In the graphical environment, risk of unintentional reboot from the Ctrl-Alt-Delete sequence is reduced because the user will be prompted before any action is taken.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109753</ident><ident system="http://cyber.mil/legacy">V-100649</ident><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-20935r304962_fix">Configure the system to disable the Ctrl-Alt-Delete sequence when using a graphical user interface by creating or editing the /etc/dconf/db/local.d/00-disable-CAD file.
+
+Add the setting to disable the Ctrl-Alt-Delete sequence for the graphical user interface:
+
+[org/gnome/settings-daemon/plugins/media-keys]
+logout=''
+
+Then update the dconf settings:
+
+# dconf update</fixtext><fix id="F-20935r304962_fix" /><check system="C-20936r304961_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is not configured to reboot the system when Ctrl-Alt-Delete is pressed when using a graphical user interface.
+
+Check that the "logout" target is not bound to an action with the following command:
+
+# grep logout /etc/dconf/db/local.d/*
+
+logout=''
+
+If the "logout" key is bound to an action, is commented out, or is missing, this is a finding.</check-content></check></Rule></Group><Group id="V-219212"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219212r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010151</version><title>The Ubuntu Operating system must disable the x86 Ctrl-Alt-Delete key sequence.</title><description>&lt;VulnDiscussion&gt;A locally logged-on user who presses Ctrl-Alt-Delete, when at the console, can reboot the system. If accidentally pressed, as could happen in the case of a mixed OS environment, this can create the risk of short-term loss of availability of systems due to unintentional reboot.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109755</ident><ident system="http://cyber.mil/legacy">V-100651</ident><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-20936r304965_fix">Configure the system to disable the Ctrl-Alt-Delete sequence for the command line with the following command:
+
+# sudo systemctl mask ctrl-alt-del.target
+
+And reload the daemon to take effect 
+
+# sudo systemctl daemon-reload</fixtext><fix id="F-20936r304965_fix" /><check system="C-20937r304964_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is not configured to reboot the system when Ctrl-Alt-Delete is pressed.
+
+Check that the "ctrl-alt-del.target" (otherwise also known as reboot.target) is not active with the following command:
+
+# systemctl status ctrl-alt-del.target
+reboot.target - Reboot
+ Loaded: loaded (/usr/lib/systemd/system/reboot.target; disabled)
+ Active: inactive (dead)
+ Docs: man:systemd.special(7)
+
+If the "ctrl-alt-del.target" is active, this is a finding.</check-content></check></Rule></Group><Group id="V-219213"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219213r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010201</version><title>The Ubuntu operating system must generate audit records for the use and modification of the tallylog file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000470-GPOS-00214, SRG-OS-000473-GPOS-00218&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109757</ident><ident system="http://cyber.mil/legacy">V-100653</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20937r304968_fix">Configure the audit system to generate an audit event for any successful/unsuccessful modifications to the "tallylog" file occur. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-w /var/log/tallylog -p wa -k logins
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20937r304968_fix" /><check system="C-20938r304967_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful modifications to the "tallylog" file occur.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep tallylog
+
+-w /var/log/tallylog -p wa -k logins
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219214"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219214r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010202</version><title>The Ubuntu operating system must generate audit records for the use and modification of faillog file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000470-GPOS-00214, SRG-OS-000473-GPOS-00218&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109759</ident><ident system="http://cyber.mil/legacy">V-100655</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20938r304971_fix">Configure the audit system to generate an audit event for any successful/unsuccessful modifications to the "faillog" file occur. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-w /var/log/faillog -p wa -k logins
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20938r304971_fix" /><check system="C-20939r304970_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful modifications to the "faillog" file occur.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep faillog
+
+-w /var/log/faillog -p wa -k logins
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219215"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219215r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010203</version><title>The Ubuntu operating system must generate audit records for the use and modification of the lastlog file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000470-GPOS-00214, SRG-OS-000473-GPOS-00218&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109761</ident><ident system="http://cyber.mil/legacy">V-100657</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20939r304974_fix">Configure the audit system to generate an audit event for any successful/unsuccessful modifications to the "lastlog" file occur. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-w /var/log/lastlog -p wa -k logins
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20939r304974_fix" /><check system="C-20940r304973_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful modifications to the "lastlog" file occur.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep lastlog
+
+-w /var/log/lastlog -p wa -k logins
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219216"><title>SRG-OS-000471-GPOS-00215</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219216r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010237</version><title>The Ubuntu operating system must generate audit records for privileged activities or other system-level access.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109763</ident><ident system="http://cyber.mil/legacy">V-100659</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20940r304977_fix">Configure the Ubuntu operating system to audit privileged activities.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-w /var/log/sudo.log -p wa -k actions
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20940r304977_fix" /><check system="C-20941r304976_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system audits privileged activities.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep sudo.log
+
+-w /var/log/sudo.log -p wa -k priv_actions
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219217"><title>SRG-OS-000472-GPOS-00217</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219217r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010238</version><title>The Ubuntu operating system must generate audit records for the /var/log/wtmp file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109765</ident><ident system="http://cyber.mil/legacy">V-100661</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20941r304980_fix">Configure the audit system to generate audit events showing start and stop times for user access via the /var/log/wtmp file.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-w /var/log/wtmp -p wa -k logins
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20941r304980_fix" /><check system="C-20942r304979_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records showing start and stop times for user access to the system via /va/rlog/wtmp.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep '/var/log/wtmp'
+
+-w /var/log/wtmp -p wa -k logins
+
+If the command does not return a line matching the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219218"><title>SRG-OS-000472-GPOS-00217</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219218r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010239</version><title>The Ubuntu operating system must generate audit records for the /var/run/wtmp file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109767</ident><ident system="http://cyber.mil/legacy">V-100663</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20942r304983_fix">Configure the audit system to generate audit events showing start and stop times for user access via the /var/run/wtmp file.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-w /var/run/wtmp -p wa -k logins
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20942r304983_fix" /><check system="C-20943r304982_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records showing start and stop times for user access to the system via /var/run/wtmp file.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep '/var/run/wtmp'
+
+-w /var/run/wtmp -p wa -k logins
+
+If the command does not return a line matching the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219219"><title>SRG-OS-000472-GPOS-00217</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219219r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010240</version><title>The Ubuntu operating system must generate audit records for the /var/log/btmp file.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109769</ident><ident system="http://cyber.mil/legacy">V-100665</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20943r304986_fix">Configure the audit system to generate audit events showing start and stop times for user access via the /var/log/btmp file.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-w /var/log/btmp -p wa -k logins
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20943r304986_fix" /><check system="C-20944r304985_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records showing start and stop times for user access to the system via /var/log/btmp file.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep '/var/log/btmp'
+
+-w /var/log/btmp -p wa -k logins
+
+If the command does not return a line matching the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219220"><title>SRG-OS-000476-GPOS-00221</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219220r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010244</version><title>The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/passwd.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000476-GPOS-00221, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPOS-00207, SRG-OS-000004-GPOS-00004&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109771</ident><ident system="http://cyber.mil/legacy">V-100667</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-000018</ident><ident system="http://cyber.mil/cci">CCI-001405</ident><ident system="http://cyber.mil/cci">CCI-001403</ident><ident system="http://cyber.mil/cci">CCI-001404</ident><ident system="http://cyber.mil/cci">CCI-002130</ident><fixtext fixref="F-20944r304989_fix">Configure the Ubuntu operating system to generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/passwd.
+
+Add or update the following rule to "/etc/audit/rules.d/stig.rules":
+
+-w /etc/passwd -p wa -k usergroup_modification
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20944r304989_fix" /><check system="C-20945r304988_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for all account creations, modifications, disabling, and termination events that affect /etc/passwd.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep passwd
+
+-w /etc/passwd -p wa -k usergroup_modification
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219221"><title>SRG-OS-000476-GPOS-00221</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219221r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010245</version><title>The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/group.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000476-GPOS-00221, SRG-OS-000239-GPOS-00089, SRG-OS-000240-GPOS-00090, SRG-OS-000241-GPOS-00091, SRG-OS-000303-GPOS-00120, SRG-OS-000458-GPOS-00203, SRG-OS-000463-GPOS-00207&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109773</ident><ident system="http://cyber.mil/legacy">V-100669</ident><ident system="http://cyber.mil/cci">CCI-002130</ident><ident system="http://cyber.mil/cci">CCI-001404</ident><ident system="http://cyber.mil/cci">CCI-001405</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-001403</ident><fixtext fixref="F-20945r304992_fix">Configure the Ubuntu operating system to generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/group.
+
+Add or update the following rule to "/etc/audit/rules.d/stig.rules":
+
+-w /etc/group -p wa -k usergroup_modification
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20945r304992_fix" /><check system="C-20946r304991_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for all account creations, modifications, disabling, and termination events that affect /etc/group.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep group
+
+-w /etc/group -p wa -k usergroup_modification
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219222"><title>SRG-OS-000476-GPOS-00221</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219222r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010246</version><title>The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/gshadow.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000476-GPOS-00221, SRG-OS-000463-GPOS-00207, SRG-OS-000458-GPOS-00203, SRG-OS-000303-GPOS-00120, SRG-OS-000241-GPOS-00091, SRG-OS-000240-GPOS-00090, SRG-OS-000239-GPOS-00089&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109775</ident><ident system="http://cyber.mil/legacy">V-100671</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-001404</ident><ident system="http://cyber.mil/cci">CCI-001403</ident><ident system="http://cyber.mil/cci">CCI-001405</ident><ident system="http://cyber.mil/cci">CCI-002130</ident><fixtext fixref="F-20946r304995_fix">Configure the Ubuntu operating system to generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/gshadow.
+
+Add or update the following rule to "/etc/audit/rules.d/stig.rules":
+
+-w /etc/gshadow -p wa -k usergroup_modification
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20946r304995_fix" /><check system="C-20947r304994_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for all account creations, modifications, disabling, and termination events that affect /etc/gshadow.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep gshadow
+
+-w /etc/gshadow -p wa -k usergroup_modification
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219223"><title>SRG-OS-000476-GPOS-00221</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219223r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010247</version><title>The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/shadow.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000476-GPOS-00221, SRG-OS-000463-GPOS-00207, SRG-OS-000458-GPOS-00203, SRG-OS-000303-GPOS-00120, SRG-OS-000241-GPOS-00091, SRG-OS-000240-GPOS-00090, SRG-OS-000239-GPOS-00089&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109777</ident><ident system="http://cyber.mil/legacy">V-100673</ident><ident system="http://cyber.mil/cci">CCI-002130</ident><ident system="http://cyber.mil/cci">CCI-001405</ident><ident system="http://cyber.mil/cci">CCI-001403</ident><ident system="http://cyber.mil/cci">CCI-001404</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20947r304998_fix">Configure the Ubuntu operating system to generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/shadow.
+
+Add or update the following rule to "/etc/audit/rules.d/stig.rules":
+
+-w /etc/shadow -p wa -k usergroup_modification
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20947r304998_fix" /><check system="C-20948r304997_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for all account creations, modifications, disabling, and termination events that affect /etc/shadow.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep shadow
+
+-w /etc/shadow -p wa -k usergroup_modification
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219224"><title>SRG-OS-000476-GPOS-00221</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219224r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010248</version><title>The Ubuntu operating system must generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/security/opasswd.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000476-GPOS-00221, SRG-OS-000463-GPOS-00207, SRG-OS-000458-GPOS-00203, SRG-OS-000303-GPOS-00120, SRG-OS-000241-GPOS-00091, SRG-OS-000240-GPOS-00090, SRG-OS-000239-GPOS-00089&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109779</ident><ident system="http://cyber.mil/legacy">V-100675</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-001403</ident><ident system="http://cyber.mil/cci">CCI-001404</ident><ident system="http://cyber.mil/cci">CCI-001405</ident><ident system="http://cyber.mil/cci">CCI-002130</ident><fixtext fixref="F-20948r305001_fix">Configure the Ubuntu operating system to generate audit records for all account creations, modifications, disabling, and termination events that affect /etc/security/opasswd.
+
+Add or update the following rule to "/etc/audit/rules.d/stig.rules":
+
+-w /etc/security/opasswd -p wa -k usergroup_modification
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20948r305001_fix" /><check system="C-20949r305000_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records for all account creations, modifications, disabling, and termination events that affect /etc/security/opasswd.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep opasswd
+
+-w /etc/security/opasswd -p wa -k usergroup_modification
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219225"><title>SRG-OS-000038-GPOS-00016</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219225r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010250</version><title>The Ubuntu operating system must produce audit records and reports containing information to establish when, where, what type, the source, and the outcome for all DoD-defined auditable events and actions in near real time.</title><description>&lt;VulnDiscussion&gt;Without establishing the when, where, type, source, and outcome of events that occurred, it would be difficult to establish, correlate, and investigate the events leading up to an outage or attack.
+
+Without the capability to generate audit records, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit record content that may be necessary to satisfy this requirement includes, for example, time stamps, source and destination addresses, user/process identifiers, event descriptions, success/fail indications, filenames involved, and access control or flow control rules invoked.
+
+Reconstruction of harmful events or forensic analysis is not possible if audit records do not contain enough information.
+
+Successful incident response and auditing relies on timely, accurate system information and analysis in order to allow the organization to identify and respond to potential incidents in a proficient manner. If the operating system does not provide the ability to centrally review the operating system logs, forensic analysis is negatively impacted.
+
+Associating event types with detected events in the Ubuntu operating system audit logs provides a means of investigating an attack; recognizing resource utilization or capacity thresholds; or identifying an improperly configured operating system.
+
+Satisfies: SRG-OS-000038-GPOS-00016, SRG-OS-000039-GPOS-00017, SRG-OS-000040-GPOS-00018, SRG-OS-000041-GPOS-00019, SRG-OS-000042-GPOS-00020, SRG-OS-000042-GPOS-00021, SRG-OS-000051-GPOS-00024, SRG-OS-000054-GPOS-00025, SRG-OS-000062-GPOS-00031, SRG-OS-000122-GPOS-00063, SRG-OS-000337-GPOS-00129, SRG-OS-000348-GPOS-00136, SRG-OS-000349-GPOS-00137, SRG-OS-000350-GPOS-00138, SRG-OS-000351-GPOS-00139, SRG-OS-000352-GPOS-00140, SRG-OS-000365-GPOS-00152, SRG-OS-000392-GPOS-00172, SRG-OS-000475-GPOS-00220&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109781</ident><ident system="http://cyber.mil/legacy">V-100677</ident><ident system="http://cyber.mil/cci">CCI-001914</ident><ident system="http://cyber.mil/cci">CCI-001875</ident><ident system="http://cyber.mil/cci">CCI-001876</ident><ident system="http://cyber.mil/cci">CCI-001877</ident><ident system="http://cyber.mil/cci">CCI-001878</ident><ident system="http://cyber.mil/cci">CCI-001879</ident><ident system="http://cyber.mil/cci">CCI-001880</ident><ident system="http://cyber.mil/cci">CCI-001814</ident><ident system="http://cyber.mil/cci">CCI-002884</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><ident system="http://cyber.mil/cci">CCI-000154</ident><ident system="http://cyber.mil/cci">CCI-000158</ident><ident system="http://cyber.mil/cci">CCI-000131</ident><ident system="http://cyber.mil/cci">CCI-000132</ident><ident system="http://cyber.mil/cci">CCI-000133</ident><ident system="http://cyber.mil/cci">CCI-000134</ident><ident system="http://cyber.mil/cci">CCI-000135</ident><ident system="http://cyber.mil/cci">CCI-000169</ident><fixtext fixref="F-20949r305004_fix">Configure the audit service to produce audit records containing the information needed to establish when (date and time) an event occurred.
+
+Install the audit service (if the audit service is not already installed) with the following command:
+
+# sudo apt-get install auditd
+
+Enable the audit service with the following command:
+
+# sudo systemctl enable auditd.service
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20949r305004_fix" /><check system="C-20950r305003_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the audit service is configured to produce audit records. 
+
+Check that the audit service is installed properly with the following command:
+
+# dpkg -l | grep auditd
+
+If the "auditd" package is not installed, this is a finding.
+
+Check that the audit service is enabled with the following command:
+
+# systemctl is-enabled auditd.service
+
+If the command above returns "disabled", this is a finding.
+
+Check that the audit service is properly running and active on the system with the following command:
+
+# systemctl is-active auditd.service
+active
+
+If the command above returns "inactive", this is a finding.</check-content></check></Rule></Group><Group id="V-219226"><title>SRG-OS-000046-GPOS-00022</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219226r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010300</version><title>The Ubuntu operating system must alert the ISSO and SA (at a minimum) in the event of an audit processing failure.</title><description>&lt;VulnDiscussion&gt;It is critical for the appropriate personnel to be aware if a system is at risk of failing to process audit logs as required. Without this notification, the security personnel may be unaware of an impending failure of the audit capability, and system operation may be adversely affected.
+
+Audit processing failures include software/hardware errors, failures in the audit capturing mechanisms, and audit storage capacity being reached or exceeded.
+
+This requirement applies to each audit data storage repository (i.e., distinct information system component where audit records are stored), the centralized audit storage capacity of organizations (i.e., all audit data storage repositories combined), or both.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109783</ident><ident system="http://cyber.mil/legacy">V-100679</ident><ident system="http://cyber.mil/cci">CCI-000139</ident><fixtext fixref="F-20950r305007_fix">Configure "auditd" service to notify the System Administrator (SA) and Information System Security Officer (ISSO) in the event of an audit processing failure. 
+
+Edit the following line in "/etc/audit/auditd.conf" to ensure that administrators are notified via email for those situations:
+
+action_mail_acct = root
+
+Restart the auditd service so the changes take effect:
+# sudo systemctl restart auditd.service</fixtext><fix id="F-20950r305007_fix" /><check system="C-20951r305006_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the System Administrator (SA) and Information System Security Officer (ISSO) (at a minimum) are notified in the event of an audit processing failure.
+
+Check that the Ubuntu operating system notifies the SA and ISSO (at a minimum) win the event of an audit processing failure with the following command:
+
+# sudo grep action_mail_acct = root /etc/audit/auditd.conf
+
+action_mail_acct = root
+
+If the value of the "action_mail_acct" keyword is not set to "root" and/or other accounts for security personnel, the "action_mail_acct" keyword is missing, or the returned line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219227"><title>SRG-OS-000047-GPOS-00023</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219227r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010301</version><title>The Ubuntu operating system must shut down by default upon audit failure (unless availability is an overriding concern).</title><description>&lt;VulnDiscussion&gt;It is critical that when the Ubuntu operating system is at risk of failing to process audit logs as required, it takes action to mitigate the failure. Audit processing failures include: software/hardware errors; failures in the audit capturing mechanisms; and audit storage capacity being reached or exceeded. Responses to audit failure depend upon the nature of the failure mode.
+
+When availability is an overriding concern, other approved actions in response to an audit failure are as follows: 
+
+1) If the failure was caused by the lack of audit record storage capacity, the Ubuntu operating system must continue generating audit records if possible (automatically restarting the audit service if necessary), overwriting the oldest audit records in a first-in-first-out manner.
+
+2) If audit records are sent to a centralized collection server and communication with this server is lost or the server fails, the Ubuntu operating system must queue audit records locally until communication is restored or until the audit records are retrieved manually. Upon restoration of the connection to the centralized collection server, action should be taken to synchronize the local audit data with the collection server.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109785</ident><ident system="http://cyber.mil/legacy">V-100681</ident><ident system="http://cyber.mil/cci">CCI-000140</ident><fixtext fixref="F-20951r305010_fix">Configure the Ubuntu operating system to shut down by default upon audit failure (unless availability is an overriding concern).
+
+Add or update the following line (depending on configuration "disk_full_action" can be set to "SYSLOG", "HALT" or "SINGLE") in "/etc/audit/auditd.conf" file:
+
+disk_full_action = HALT
+
+Restart the auditd service so the changes take effect:
+# sudo systemctl restart auditd.service</fixtext><fix id="F-20951r305010_fix" /><check system="C-20952r305009_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system takes the appropriate action when the audit storage volume is full. 
+
+Check that the Ubuntu operating system takes the appropriate action when the audit storage volume is full with the following command:
+
+# sudo grep disk_full_action /etc/audit/auditd.conf
+
+disk_full_action = HALT
+
+If the value of the "disk_full_action" option is not "SYSLOG", "SINGLE", or "HALT", or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219228"><title>SRG-OS-000058-GPOS-00028</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219228r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010305</version><title>The Ubuntu operating system must be configured so that audit log files cannot be read or write-accessible by unauthorized users.</title><description>&lt;VulnDiscussion&gt;If audit information were to become compromised, then forensic analysis and discovery of the true source of potentially malicious system activity is impossible to achieve.
+
+To ensure the veracity of audit information, the operating system must protect audit information from unauthorized modification.
+
+Audit information includes all information (e.g., audit records, audit settings, audit reports) needed to successfully audit information system activity.
+
+Satisfies: SRG-OS-000058-GPOS-00028, SRG-OS-000057-GPOS-00027&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109787</ident><ident system="http://cyber.mil/legacy">V-100683</ident><ident system="http://cyber.mil/cci">CCI-000162</ident><ident system="http://cyber.mil/cci">CCI-000163</ident><fixtext fixref="F-20952r305013_fix">Configure the audit log files to have a mode of "0600" or less permissive.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, configure the audit log files to have a mode of "0600" or less permissive by using the following command:
+
+# sudo chmod 0600 /var/log/audit/*</fixtext><fix id="F-20952r305013_fix" /><check system="C-20953r305012_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the audit log files have a mode of "0600" or less permissive.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, check if the audit log files have a mode of "0600" or less by using the following command:
+
+# sudo stat -c "%n %a" /var/log/audit/*
+/var/log/audit/audit.log 600
+
+If the audit log files have a mode more permissive than "0600", this is a finding.</check-content></check></Rule></Group><Group id="V-219229"><title>SRG-OS-000058-GPOS-00028</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219229r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010306</version><title>The Ubuntu operating system must permit only authorized accounts ownership of the audit log files.</title><description>&lt;VulnDiscussion&gt;If audit information were to become compromised, then forensic analysis and discovery of the true source of potentially malicious system activity is impossible to achieve.
+
+To ensure the veracity of audit information, the operating system must protect audit information from unauthorized modification.
+
+Audit information includes all information (e.g., audit records, audit settings, audit reports) needed to successfully audit information system activity.
+
+Satisfies: SRG-OS-000058-GPOS-00028, SRG-OS-000057-GPOS-00027&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109789</ident><ident system="http://cyber.mil/legacy">V-100685</ident><ident system="http://cyber.mil/cci">CCI-000162</ident><ident system="http://cyber.mil/cci">CCI-000163</ident><fixtext fixref="F-20953r305016_fix">Configure the audit log files to be owned by "root" user.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, configure the audit log files to be owned by "root" user by using the following command:
+
+# sudo chown root /var/log/audit/*</fixtext><fix id="F-20953r305016_fix" /><check system="C-20954r305015_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the audit log files are owned by "root" account.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, check if the audit log files are owned by the "root" user by using the following command:
+
+# sudo stat -c "%n %U" /var/log/audit/*
+/var/log/audit/audit.log root
+
+If the audit log files are owned by an user other than "root", this is a finding.</check-content></check></Rule></Group><Group id="V-219230"><title>SRG-OS-000058-GPOS-00028</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219230r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010307</version><title>The Ubuntu operating system must permit only authorized groups to own the audit log files.</title><description>&lt;VulnDiscussion&gt;If audit information were to become compromised, then forensic analysis and discovery of the true source of potentially malicious system activity is impossible to achieve.
+
+To ensure the veracity of audit information, the operating system must protect audit information from unauthorized modification.
+
+Audit information includes all information (e.g., audit records, audit settings, audit reports) needed to successfully audit information system activity.
+
+Satisfies: SRG-OS-000058-GPOS-00028, SRG-OS-000057-GPOS-00027&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109791</ident><ident system="http://cyber.mil/legacy">V-100687</ident><ident system="http://cyber.mil/cci">CCI-000163</ident><ident system="http://cyber.mil/cci">CCI-000162</ident><fixtext fixref="F-20954r305019_fix">Configure the audit log files to be owned by "root" group.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, configure the audit log files to be owned by "root" group by using the following command:
+
+# sudo chown :root /var/log/audit/*</fixtext><fix id="F-20954r305019_fix" /><check system="C-20955r305018_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the audit log files are owned by "root" group.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, check if the audit log files are owned by the "root" group by using the following command:
+
+# sudo stat -c "%n %G" /var/log/audit/*
+/var/log/audit/audit.log root
+
+If the audit log files are owned by a group other than "root", this is a finding.</check-content></check></Rule></Group><Group id="V-219231"><title>SRG-OS-000059-GPOS-00029</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219231r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010308</version><title>The Ubuntu operating system must be configured so that the audit log directory is not write-accessible by unauthorized users.</title><description>&lt;VulnDiscussion&gt;If audit information were to become compromised, then forensic analysis and discovery of the true source of potentially malicious system activity is impossible to achieve.
+
+To ensure the veracity of audit information, the operating system must protect audit information from unauthorized deletion. This requirement can be achieved through multiple methods, which will depend upon system architecture and design.
+
+Audit information includes all information (e.g., audit records, audit settings, audit reports) needed to successfully audit information system activity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109793</ident><ident system="http://cyber.mil/legacy">V-100689</ident><ident system="http://cyber.mil/cci">CCI-000164</ident><fixtext fixref="F-20955r305022_fix">Configure the audit log directory to have a mode of "0750" or less permissive.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, configure the audit log directory to have a mode of "0750" or less permissive by using the following command:
+
+# chmod -R g-w,o-rwx /var/log/audit</fixtext><fix id="F-20955r305022_fix" /><check system="C-20956r305021_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the audit log directory has a mode of "0750" or less permissive.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, check if the directory has a mode of "0750" or less by using the following command:
+
+# sudo stat -c "%n %a" /var/log/audit
+/var/log/audit 750
+
+If the audit log directory has a mode more permissive than "0750", this is a finding.</check-content></check></Rule></Group><Group id="V-219232"><title>SRG-OS-000059-GPOS-00029</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219232r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010309</version><title>The Ubuntu operating system must allow only authorized accounts to own the audit log directory.</title><description>&lt;VulnDiscussion&gt;If audit information were to become compromised, then forensic analysis and discovery of the true source of potentially malicious system activity is impossible to achieve.
+
+To ensure the veracity of audit information, the operating system must protect audit information from unauthorized deletion. This requirement can be achieved through multiple methods, which will depend upon system architecture and design.
+
+Audit information includes all information (e.g., audit records, audit settings, audit reports) needed to successfully audit information system activity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109795</ident><ident system="http://cyber.mil/legacy">V-100691</ident><ident system="http://cyber.mil/cci">CCI-000164</ident><fixtext fixref="F-20956r305025_fix">Configure the audit log directory to be owned by "root" user.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, configure the audit log directory to be owned by "root" user by using the following command:
+
+# chown -R root /var/log/audit</fixtext><fix id="F-20956r305025_fix" /><check system="C-20957r305024_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the audit log directory is owned by "root" account.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, check if the directory is owned by the "root" user by using the following command:
+
+# sudo stat -c "%n %U" /var/log/audit
+/var/log/audit root
+
+If the audit log directory is owned by an user other than "root", this is a finding.</check-content></check></Rule></Group><Group id="V-219233"><title>SRG-OS-000059-GPOS-00029</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219233r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010310</version><title>The Ubuntu operating system must ensure only authorized groups can own the audit log directory and its underlying files.</title><description>&lt;VulnDiscussion&gt;If audit information were to become compromised, then forensic analysis and discovery of the true source of potentially malicious system activity is impossible to achieve.
+
+To ensure the veracity of audit information, the operating system must protect audit information from unauthorized deletion. This requirement can be achieved through multiple methods, which will depend upon system architecture and design.
+
+Audit information includes all information (e.g., audit records, audit settings, audit reports) needed to successfully audit information system activity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109797</ident><ident system="http://cyber.mil/legacy">V-100693</ident><ident system="http://cyber.mil/cci">CCI-000164</ident><fixtext fixref="F-20957r305028_fix">Configure the audit log directory to be owned by "root" group.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, configure the audit log directory to be owned by "root" group by using the following command:
+
+# chown -R :root /var/log/audit</fixtext><fix id="F-20957r305028_fix" /><check system="C-20958r305027_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the audit log directory is owned by "root" group.
+
+First determine where the audit logs are stored with the following command:
+
+# sudo grep -iw log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Using the path of the directory containing the audit logs, check if the directory is owned by the "root" group by using the following command:
+
+# sudo stat -c "%n %G" /var/log/audit
+/var/log/audit root
+
+If the audit log directory is owned by a group other than "root", this is a finding.</check-content></check></Rule></Group><Group id="V-219234"><title>SRG-OS-000063-GPOS-00032</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219234r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010311</version><title>The Ubuntu operating system must be configured so that audit configuration files are not write-accessible by unauthorized users.</title><description>&lt;VulnDiscussion&gt;Without the capability to restrict which roles and individuals can select which events are audited, unauthorized personnel may be able to prevent the auditing of critical events. Misconfigured audits may degrade the system's performance by overwhelming the audit log. Misconfigured audits may also make it more difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109799</ident><ident system="http://cyber.mil/legacy">V-100695</ident><ident system="http://cyber.mil/cci">CCI-000171</ident><fixtext fixref="F-20958r305031_fix">Configure "/etc/audit/audit.rules", "/etc/audit/rules.d/*" and "/etc/audit/auditd.conf" files to have a mode of 0640 by using the following command:
+
+# chmod -R 0640 /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
+
+Note: The "root" account must be used to edit any files in the /etc/audit and /etc/audit/rules.d/ directories.</fixtext><fix id="F-20958r305031_fix" /><check system="C-20959r305030_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that "/etc/audit/audit.rules", "/etc/audit/rules.d/*" and "/etc/audit/auditd.conf" files have a mode of 0640 or less permissive by using the following command:
+
+# sudo ls -al /etc/audit/ /etc/audit/rules.d/
+
+/etc/audit/:
+
+drwxr-x--- 3 root root 4096 Nov 25 11:02 .
+
+drwxr-xr-x 130 root root 12288 Dec 19 13:42 ..
+
+-rw-r----- 1 root root 804 Nov 25 11:01 auditd.conf
+
+-rw-r----- 1 root root 9128 Dec 27 09:56 audit.rules
+
+-rw-r----- 1 root root 9373 Dec 27 09:56 audit.rules.prev
+
+-rw-r----- 1 root root 127 Feb 7 2018 audit-stop.rules
+
+drwxr-x--- 2 root root 4096 Dec 27 09:56 rules.d
+
+/etc/audit/rules.d/:
+
+drwxr-x--- 2 root root 4096 Dec 27 09:56 .
+
+drwxr-x--- 3 root root 4096 Nov 25 11:02 ..
+
+-rw-r----- 1 root root 10357 Dec 27 09:56 stig.rules
+
+If "/etc/audit/audit.rule","/etc/audit/rules.d/*" or "/etc/audit/auditd.conf" file have a mode more permissive than "0640", this is a finding.</check-content></check></Rule></Group><Group id="V-219235"><title>SRG-OS-000063-GPOS-00032</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219235r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010312</version><title>The Ubuntu operating system must permit only authorized accounts to own the audit configuration files.</title><description>&lt;VulnDiscussion&gt;Without the capability to restrict which roles and individuals can select which events are audited, unauthorized personnel may be able to prevent the auditing of critical events. Misconfigured audits may degrade the system's performance by overwhelming the audit log. Misconfigured audits may also make it more difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109801</ident><ident system="http://cyber.mil/legacy">V-100697</ident><ident system="http://cyber.mil/cci">CCI-000171</ident><fixtext fixref="F-20959r305034_fix">Configure "/etc/audit/audit.rules", "/etc/audit/rules.d/*" and "/etc/audit/auditd.conf" files to be owned by root user by using the following command:
+
+# chown root /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
+
+Note: The "root" account must be used to edit any files in the /etc/audit and /etc/audit/rules.d/ directories.</fixtext><fix id="F-20959r305034_fix" /><check system="C-20960r305033_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that "/etc/audit/audit.rules", "/etc/audit/rules.d/*" and "/etc/audit/auditd.conf" files are owned by root account by using the following command:
+
+# sudo ls -al /etc/audit/ /etc/audit/rules.d/
+
+/etc/audit/:
+
+drwxr-x--- 3 root root 4096 Nov 25 11:02 .
+
+drwxr-xr-x 130 root root 12288 Dec 19 13:42 ..
+
+-rw-r----- 1 root root 804 Nov 25 11:01 auditd.conf
+
+-rw-r----- 1 root root 9128 Dec 27 09:56 audit.rules
+
+-rw-r----- 1 root root 9373 Dec 27 09:56 audit.rules.prev
+
+-rw-r----- 1 root root 127 Feb 7 2018 audit-stop.rules
+
+drwxr-x--- 2 root root 4096 Dec 27 09:56 rules.d
+
+/etc/audit/rules.d/:
+
+drwxr-x--- 2 root root 4096 Dec 27 09:56 .
+
+drwxr-x--- 3 root root 4096 Nov 25 11:02 ..
+
+-rw-r----- 1 root root 10357 Dec 27 09:56 stig.rules
+
+If "/etc/audit/audit.rules" or "/etc/audit/rules.d/*" or "/etc/audit/auditd.conf" file is owned by a user other than "root", this is a finding.</check-content></check></Rule></Group><Group id="V-219236"><title>SRG-OS-000063-GPOS-00032</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219236r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010313</version><title>The Ubuntu operating system must permit only authorized groups to own the audit configuration files.</title><description>&lt;VulnDiscussion&gt;Without the capability to restrict which roles and individuals can select which events are audited, unauthorized personnel may be able to prevent the auditing of critical events. Misconfigured audits may degrade the system's performance by overwhelming the audit log. Misconfigured audits may also make it more difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109803</ident><ident system="http://cyber.mil/legacy">V-100699</ident><ident system="http://cyber.mil/cci">CCI-000171</ident><fixtext fixref="F-20960r305037_fix">Configure "/etc/audit/audit.rules", "/etc/audit/rules.d/*" and "/etc/audit/auditd.conf" files to be owned by root group by using the following command:
+
+# chown :root /etc/audit/audit*.{rules,conf} /etc/audit/rules.d/*
+
+Note: The "root" account must be used to edit any files in the /etc/audit and /etc/audit/rules.d/ directories.</fixtext><fix id="F-20960r305037_fix" /><check system="C-20961r305036_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that "/etc/audit/audit.rules", "/etc/audit/rules.d/*" and "/etc/audit/auditd.conf" files are owned by root group by using the following command:
+
+# sudo ls -al /etc/audit/ /etc/audit/rules.d/
+
+/etc/audit/:
+
+drwxr-x--- 3 root root 4096 Nov 25 11:02 .
+
+drwxr-xr-x 130 root root 12288 Dec 19 13:42 ..
+
+-rw-r----- 1 root root 804 Nov 25 11:01 auditd.conf
+
+-rw-r----- 1 root root 9128 Dec 27 09:56 audit.rules
+
+-rw-r----- 1 root root 9373 Dec 27 09:56 audit.rules.prev
+
+-rw-r----- 1 root root 127 Feb 7 2018 audit-stop.rules
+
+drwxr-x--- 2 root root 4096 Dec 27 09:56 rules.d
+
+/etc/audit/rules.d/:
+
+drwxr-x--- 2 root root 4096 Dec 27 09:56 .
+
+drwxr-x--- 3 root root 4096 Nov 25 11:02 ..
+
+-rw-r----- 1 root root 10357 Dec 27 09:56 stig.rules
+
+If "/etc/audit/audit.rules" or "/etc/audit/rules.d/*" or "/etc/audit/auditd.conf" file is owned by a group other than "root", this is a finding.</check-content></check></Rule></Group><Group id="V-219237"><title>SRG-OS-000341-GPOS-00132</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219237r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010314</version><title>The Ubuntu operating system must allocate audit record storage capacity to store at least one weeks worth of audit records, when audit records are not immediately sent to a central audit record storage facility.</title><description>&lt;VulnDiscussion&gt;In order to ensure Ubuntu operating systems have sufficient storage capacity in which to write the audit logs, Ubuntu operating system needs to be able to allocate audit record storage capacity.
+
+The task of allocating audit record storage capacity is usually performed during initial installation of the Ubuntu operating system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109805</ident><ident system="http://cyber.mil/legacy">V-100701</ident><ident system="http://cyber.mil/cci">CCI-001849</ident><fixtext fixref="F-20961r305040_fix">Allocate enough storage capacity for at least one week's worth of audit records when audit records are not immediately sent to a central audit record storage facility.
+
+If audit records are stored on a partition made specifically for audit records, use the "parted" program to resize the partition with sufficient space to contain one week's worth of audit records.
+
+If audit records are not stored on a partition made specifically for audit records, a new partition with sufficient amount of space will need be to be created.
+
+Set the auditd server to point to the mount point where the audit records must be located:
+
+# sudo sed -i -E 's@^(log_file\s*=\s*).*@\1 &lt;log mountpoint&gt;/audit.log@' /etc/audit/auditd.conf
+
+where &lt;log mountpoint&gt; is the aforementioned mount point.</fixtext><fix id="F-20961r305040_fix" /><check system="C-20962r305039_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system allocates audit record storage capacity to store at least one week's worth of audit records when audit records are not immediately sent to a central audit record storage facility.
+
+Determine which partition the audit records are being written to with the following command:
+
+# sudo grep log_file /etc/audit/auditd.conf
+log_file = /var/log/audit/audit.log
+
+Check the size of the partition that audit records are written to (with the example being /var/log/audit/) with the following command:
+
+# df –h /var/log/audit/
+/dev/sda2 24G 10.4G 13.6G 43% /var/log/audit
+
+If the audit records are not written to a partition made specifically for audit records (/var/log/audit is a separate partition), determine the amount of space being used by other files in the partition with the following command:
+
+#du –sh [audit_partition]
+1.8G /var/log/audit
+
+Note: The partition size needed to capture a week's worth of audit records is based on the activity level of the system and the total storage capacity available. In normal circumstances, 10.0 GB of storage space for audit records will be sufficient.
+
+If the audit record partition is not allocated for sufficient storage capacity, this is a finding.</check-content></check></Rule></Group><Group id="V-219238"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219238r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010315</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the su command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">V-100703</ident><ident system="http://cyber.mil/legacy">SV-109807</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20962r569457_fix">Configure the Ubuntu operating system to generate audit records when successful/unsuccessful attempts to use the "su" command occur.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/bin/su -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-priv_change 
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load 
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.</fixtext><fix id="F-20962r569457_fix" /><check system="C-20963r569456_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system generates audit records when successful/unsuccessful attempts to use the "su" command occur.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep '/bin/su'
+
+-a always,exit -F path=/bin/su -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-priv_change
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219239"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219239r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010316</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chfn command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109809</ident><ident system="http://cyber.mil/legacy">V-100705</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20963r305046_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "chfn" command.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-chfn
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load 
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.</fixtext><fix id="F-20963r305046_fix" /><check system="C-20964r305045_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system generates audit records when successful/unsuccessful attempts to use of the "chfn" command occur. 
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep '/usr/bin/chfn'
+
+-a always,exit -F path=/usr/bin/chfn -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-chfn
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219240"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219240r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010317</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the mount command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109811</ident><ident system="http://cyber.mil/legacy">V-100707</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20964r305049_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "mount" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/bin/mount -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-mount
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load 
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.</fixtext><fix id="F-20964r305049_fix" /><check system="C-20965r305048_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system generates audit records when successful/unsuccessful attempts to use of the "mount" command occur.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep '/bin/mount'
+
+-a always,exit -F path=/bin/mount -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-mount
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219241"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219241r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010318</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the umount command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109813</ident><ident system="http://cyber.mil/legacy">V-100709</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20965r305052_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "umount" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/bin/umount -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-umount
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load 
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.</fixtext><fix id="F-20965r305052_fix" /><check system="C-20966r305051_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system generates audit records when successful/unsuccessful attempts to use of the "umount" command occur.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep '/bin/umount'
+
+-a always,exit -F path=/bin/umount -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-umount
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219242"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219242r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010319</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the ssh-agent command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109815</ident><ident system="http://cyber.mil/legacy">V-100711</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20966r305055_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "ssh-agent" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-ssh
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load 
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.</fixtext><fix id="F-20966r305055_fix" /><check system="C-20967r305054_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "ssh-agent" command occur.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep '/usr/bin/ssh-agent'
+
+-a always,exit -F path=/usr/bin/ssh-agent -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-ssh
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219243"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219243r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010320</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the ssh-keysign command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109817</ident><ident system="http://cyber.mil/legacy">V-100713</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20967r305058_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "ssh-keysign" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-ssh
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load 
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.</fixtext><fix id="F-20967r305058_fix" /><check system="C-20968r305057_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "ssh-keysign" command occur.
+
+Check the configured audit rules with the following commands:
+
+#sudo auditctl -l | grep ssh-keysign
+
+-a always,exit -F path=/usr/lib/openssh/ssh-keysign -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-ssh
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219244"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219244r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010321</version><title>The Ubuntu operating system must generate audit records for any usage of the setxattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109819</ident><ident system="http://cyber.mil/legacy">V-100715</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20968r305061_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "setxattr" system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S setxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S setxattr -F auid=0 -k perm_mod 
+-a always,exit -F arch=b64 -S setxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S setxattr -F auid=0 -k perm_mod 
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20968r305061_fix" /><check system="C-20969r305060_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "setxattr" system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep setxattr
+
+-a always,exit -F arch=b32 -S setxattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b32 -S setxattr -F auid=0 -k perm_mod 
+-a always,exit -F arch=b64 -S setxattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b64 -S setxattr -F auid=0 -k perm_mod 
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219245"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219245r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010322</version><title>The Ubuntu operating system must generate audit records for any usage of the lsetxattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109821</ident><ident system="http://cyber.mil/legacy">V-100717</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20969r305064_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "lsetxattr" system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S lsetxattr -F auid=0 -k perm_mod 
+-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lsetxattr -F auid=0 -k perm_mod 
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20969r305064_fix" /><check system="C-20970r305063_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "lsetxattr" system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep lsetxattr
+
+-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b32 -S lsetxattr -F auid=0 -k perm_mod 
+-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b64 -S lsetxattr -F auid=0 -k perm_mod
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219246"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219246r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010323</version><title>The Ubuntu operating system must generate audit records for any usage of the fsetxattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109823</ident><ident system="http://cyber.mil/legacy">V-100719</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20970r305067_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fsetxattr" system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fsetxattr -F auid=0 -k perm_mod
+-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fsetxattr -F auid=0 -k perm_mod
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20970r305067_fix" /><check system="C-20971r305066_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "fsetxattr" system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep fsetxattr
+
+-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b32 -S fsetxattr -F auid=0 -k perm_mod 
+-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b64 -S fsetxattr -F auid=0 -k perm_mod 
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219247"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219247r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010324</version><title>The Ubuntu operating system must generate audit records for any usage of the removexattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110019</ident><ident system="http://cyber.mil/legacy">V-100915</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20971r305070_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "removexattr" system call. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S removexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S removexattr -F auid=0 -k perm_mod
+-a always,exit -F arch=b64 -S removexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S removexattr -F auid=0 -k perm_mod
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20971r305070_fix" /><check system="C-20972r305069_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "removexattr" system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep perm_mod
+
+-a always,exit -F arch=b32 -S removexattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b32 -S removexattr -F auid=0 -k perm_mod 
+-a always,exit -F arch=b64 -S removexattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b64 -S removexattr -F auid=0 -k perm_mod 
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219248"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219248r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010325</version><title>The Ubuntu operating system must generate audit records for any usage of the lremovexattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109825</ident><ident system="http://cyber.mil/legacy">V-100721</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20972r305073_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "lremovexattr" system call. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S lremovexattr -F auid=0 -k perm_mod
+-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S lremovexattr -F auid=0 -k perm_mod
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20972r305073_fix" /><check system="C-20973r305072_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system is configured to audit the execution of the "lremovexattr" system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | lremovexattr
+
+-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b32 -S lremovexattr -F auid=0 -k perm_mod 
+-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b64 -S lremovexattr -F auid=0 -k perm_mod 
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219249"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219249r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010326</version><title>The Ubuntu operating system must generate audit records for any usage of the fremovexattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPOS-00206, SRG-OS-000466-GPOS-00210&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109827</ident><ident system="http://cyber.mil/legacy">V-100723</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20973r305076_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fremovexattr" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b32 -S fremovexattr -F auid=0 -k perm_mod
+-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_mod
+-a always,exit -F arch=b64 -S fremovexattr -F auid=0 -k perm_mod
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20973r305076_fix" /><check system="C-20974r305075_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "fremovexattr" system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep fremovexattr
+
+-a always,exit -F arch=b32 -S fremovexattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b32 -S fremovexattr -F auid=0 -k perm_mod 
+-a always,exit -F arch=b64 -S fremovexattr -F auid&gt;=1000 -F auid!=-1 -k perm_mod
+-a always,exit -F arch=b64 -S fremovexattr -F auid=0 -k perm_mod
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219250"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219250r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010327</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chown system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPOS-00206&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109829</ident><ident system="http://cyber.mil/legacy">V-100725</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20974r305079_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chown" system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules":
+
+-a always,exit -F arch=b32 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b64 -S chown -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20974r305079_fix" /><check system="C-20975r305078_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "chown" system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep chown
+
+-a always,exit -F arch=b32 -S chown -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b64 -S chown -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219251"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219251r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010328</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the fchown system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPOS-00206&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109831</ident><ident system="http://cyber.mil/legacy">V-100727</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20975r569460_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fchown" system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules":
+
+-a always,exit -F arch=b32 -S fchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b64 -S fchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20975r569460_fix" /><check system="C-20976r569459_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "fchown" system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep fchown
+
+-a always,exit -F arch=b32 -S fchown -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b64 -S fchown -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219252"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219252r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010329</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the fchownat system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109833</ident><ident system="http://cyber.mil/legacy">V-100729</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20976r305085_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fchownat" system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules":
+
+-a always,exit -F arch=b32 -S fchownat -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b64 -S fchownat -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20976r305085_fix" /><check system="C-20977r305084_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "fchownat" system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep fchownat
+
+-a always,exit -F arch=b32 -S fchownat -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b64 -S fchownat -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219253"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219253r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010330</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the lchown system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPOS-00206&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109835</ident><ident system="http://cyber.mil/legacy">V-100731</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20977r305088_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "lchown" system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules":
+
+-a always,exit -F arch=b32 -S lchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b64 -S lchown -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20977r305088_fix" /><check system="C-20978r305087_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "lchown" system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep lchown
+
+-a always,exit -F arch=b32 -S lchown -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b64 -S lchown -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219254"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219254r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010331</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chmod system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPOS-00206&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109837</ident><ident system="http://cyber.mil/legacy">V-100733</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20978r305091_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chmod" system call. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules":
+
+-a always,exit -F arch=b32 -S chmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b64 -S chmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20978r305091_fix" /><check system="C-20979r305090_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "chmod" system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep chmod
+
+-a always,exit -F arch=b32 -S chmod -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b64 -S chmod -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219255"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219255r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010332</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the fchmod system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPOS-00206&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109839</ident><ident system="http://cyber.mil/legacy">V-100735</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20979r305094_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fchmod" system call. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules":
+
+-a always,exit -F arch=b32 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b64 -S fchmod -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20979r305094_fix" /><check system="C-20980r305093_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "fchmod" system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep fchmod
+
+-a always,exit -F arch=b32 -S fchmod -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b64 -S fchmod -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219256"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219256r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010333</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the fchmodat system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000462-GPOS-00206&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109841</ident><ident system="http://cyber.mil/legacy">V-100737</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20980r305097_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "fchmodat" system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b64 -S fchmodat -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20980r305097_fix" /><check system="C-20981r305096_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "fchmodat" system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep fchmodat
+-a always,exit -F arch=b32 -S fchmodat -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b64 -S fchmodat -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219257"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219257r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010334</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the open system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000474-GPOS-00219&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109843</ident><ident system="http://cyber.mil/legacy">V-100739</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20981r305100_fix">Configure the audit system to generate an audit event for any unsuccessful use of the "open" system call. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20981r305100_fix" /><check system="C-20982r305099_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when unsuccessful attempts to use the "open" system call occur.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep open
+
+-a always,exit -F arch=b32 -S open -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b32 -S open -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S open -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S open -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219261"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219261r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010338</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the openat system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000474-GPOS-00219&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109851</ident><ident system="http://cyber.mil/legacy">V-100747</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20985r305112_fix">Configure the audit system to generate an audit event for any unsuccessful use of the "openat" system call. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20985r305112_fix" /><check system="C-20986r305111_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when unsuccessful attempts to use the "openat" system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep openat
+
+-a always,exit -F arch=b32 -S openat -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b32 -S openat -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S openat -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S openat -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219262"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219262r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010339</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the open_by_handle_at system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033, SRG-OS-000474-GPOS-00219&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109853</ident><ident system="http://cyber.mil/legacy">V-100749</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20986r305115_fix">Configure the audit system to generate an audit event for any unsuccessful use of the "open_by_handle_at" system call. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20986r305115_fix" /><check system="C-20987r305114_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when unsuccessful attempts to use the "open_by_handle_at" system call.
+
+Check the configured audit rules with the following command:
+
+# sudo auditctl -l | grep open_by_handle_at
+
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b32 -S open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S open_by_handle_at -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219263"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219263r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010340</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the sudo command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109855</ident><ident system="http://cyber.mil/legacy">V-100751</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20987r305118_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "sudo" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k priv_cmd
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20987r305118_fix" /><check system="C-20988r305117_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "sudo" command. 
+
+Check the configured audit rules with the following command:
+
+# sudo auditctl -l | grep /usr/bin/sudo
+
+-a always,exit -F path=/usr/bin/sudo -F perm=x -F auid&gt;=1000 -F auid!=-1 -k priv_cmd
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219264"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219264r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010341</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the sudoedit command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109857</ident><ident system="http://cyber.mil/legacy">V-100753</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20988r305121_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "sudoedit" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules":
+
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k priv_cmd
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20988r305121_fix" /><check system="C-20989r305120_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "sudoedit" command occur.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep /usr/bin/sudoedit
+
+-a always,exit -F path=/usr/bin/sudoedit -F perm=x -F auid&gt;=1000 -F auid!=-1 -k priv_cmd
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219265"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219265r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010342</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chsh command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109859</ident><ident system="http://cyber.mil/legacy">V-100755</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20989r305124_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chsh" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k priv_cmd
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20989r305124_fix" /><check system="C-20990r305123_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "chsh" command.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep chsh
+
+-a always,exit -F path=/usr/bin/chsh -F perm=x -F auid&gt;=1000 -F auid!=-1 -k priv_cmd
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Notes: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219266"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219266r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010343</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the newgrp command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109861</ident><ident system="http://cyber.mil/legacy">V-100757</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20990r305127_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "newgrp" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k priv_cmd
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20990r305127_fix" /><check system="C-20991r305126_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "newgrp" command occur.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep newgrp
+
+-a always,exit -F path=/usr/bin/newgrp -F perm=x -F auid&gt;=1000 -F auid!=-1 -k priv_cmd
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219267"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219267r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010344</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chcon command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109863</ident><ident system="http://cyber.mil/legacy">V-100759</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20991r305130_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chcon" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20991r305130_fix" /><check system="C-20992r305129_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "chcon" command occur.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep chcon
+
+-a always,exit -F path=/usr/bin/chcon -F perm=x -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219268"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219268r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010345</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the apparmor_parser command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109865</ident><ident system="http://cyber.mil/legacy">V-100761</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20992r305133_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "apparmor_parser" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20992r305133_fix" /><check system="C-20993r305132_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "apparmor_parser" command occur.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep apparmor_parser
+
+-a always,exit -F path=/sbin/apparmor_parser -F perm=x -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219269"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219269r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010346</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the setfacl command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109867</ident><ident system="http://cyber.mil/legacy">V-100763</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20993r305136_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "setfacl" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20993r305136_fix" /><check system="C-20994r305135_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "setfacl" command occur.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep setfacl
+
+-a always,exit -F path=/usr/bin/setfacl -F perm=x -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219270"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219270r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010347</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chacl command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109869</ident><ident system="http://cyber.mil/legacy">V-100765</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20994r305139_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "chacl" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20994r305139_fix" /><check system="C-20995r305138_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "chacl" command occur.
+
+Check the currently configured audit rules with the following command:
+
+# sudo audtctl -l | grep chacl
+
+-a always,exit -F path=/usr/bin/chacl -F perm=x -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219271"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219271r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010348</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the passwd command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109871</ident><ident system="http://cyber.mil/legacy">V-100767</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20995r305142_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "passwd" command. 
+
+Add or update the following rule in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;=500 -F auid!=4294967295 -k privileged-passwd
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20995r305142_fix" /><check system="C-20996r305141_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "passwd" command. 
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -w passwd
+
+-a always,exit -F path=/usr/bin/passwd -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-passwd
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219272"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219272r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010349</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the unix_update command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109873</ident><ident system="http://cyber.mil/legacy">V-100769</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20996r305145_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "unix_update" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/sbin/unix_update -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-unix-update
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20996r305145_fix" /><check system="C-20997r305144_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "unix_update" command.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -w unix_update
+
+-a always,exit -F path=/sbin/unix_update -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-unix-update
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219273"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219273r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010350</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the gpasswd command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109875</ident><ident system="http://cyber.mil/legacy">V-100771</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20997r305148_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the gpasswd command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-gpasswd
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20997r305148_fix" /><check system="C-20998r305147_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "gpasswd" command. 
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -w gpasswd
+
+-a always,exit -F path=/usr/bin/gpasswd -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-gpasswd
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219274"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219274r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010351</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the chage command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109877</ident><ident system="http://cyber.mil/legacy">V-100773</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20998r305151_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "chage" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-chage
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20998r305151_fix" /><check system="C-20999r305150_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "chage" command.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -w chage
+
+-a always,exit -F path=/usr/bin/chage -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-chage
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219275"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219275r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010352</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the usermod command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109879</ident><ident system="http://cyber.mil/legacy">V-100775</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-20999r305154_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "usermod" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-usermod
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-20999r305154_fix" /><check system="C-21000r305153_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "usermod" command.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -w usermod
+
+-a always,exit -F path=/usr/sbin/usermod -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-usermod
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219276"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219276r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010353</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the crontab command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110021</ident><ident system="http://cyber.mil/legacy">V-100917</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21000r305157_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "crontab" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-crontab
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21000r305157_fix" /><check system="C-21001r305156_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "crontab" command.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -w crontab
+
+-a always,exit -F path=/usr/bin/crontab -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-crontab
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219277"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219277r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010354</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the pam_timestamp_check command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109881</ident><ident system="http://cyber.mil/legacy">V-100777</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21001r305160_fix">Configure the audit system to generate an audit event for any successful/unsuccessful uses of the "pam_timestamp_check" command. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;=1000 -F auid!=4294967295 -k privileged-pam_timestamp_check
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21001r305160_fix" /><check system="C-21002r305159_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that an audit event is generated for any successful/unsuccessful use of the "pam_timestamp_check" command.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -w pam_timestamp_check
+
+-a always,exit -F path=/usr/sbin/pam_timestamp_check -F perm=x -F auid&gt;=1000 -F auid!=-1 -k privileged-pam_timestamp_check
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219278"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219278r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010355</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the init_module syscall.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109883</ident><ident system="http://cyber.mil/legacy">V-100779</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21002r305163_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "init_module" syscall. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S init_module -F auid&gt;=1000 -F auid!=4294967295 -k module_chng
+-a always,exit -F arch=b64 -S init_module -F auid&gt;=1000 -F auid!=4294967295 -k module_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21002r305163_fix" /><check system="C-21003r305162_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "init_module" syscall.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -w init_module
+
+-a always,exit -F arch=b32 -S init_module -F auid&gt;=1000 -F auid!=-1 -k module_chng
+-a always,exit -F arch=b64 -S init_module -F auid&gt;=1000 -F auid!=-1 -k module_chng
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219279"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219279r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010356</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the finit_module syscall.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109885</ident><ident system="http://cyber.mil/legacy">V-100781</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21003r305166_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "finit_module" syscall. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S finit_module -F auid&gt;=1000 -F auid!=4294967295 -k module_chng
+-a always,exit -F arch=b64 -S finit_module -F auid&gt;=1000 -F auid!=4294967295 -k module_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21003r305166_fix" /><check system="C-21004r305165_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "finit_module" syscall.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -w finit_module
+
+-a always,exit -F arch=b32 -S finit_module -F auid&gt;=1000 -F auid!=-1 -k module_chng
+-a always,exit -F arch=b64 -S finit_module -F auid&gt;=1000 -F auid!=-1 -k module_chng
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219280"><title>SRG-OS-000064-GPOS-00033</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219280r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010357</version><title>The Ubuntu operating system must generate audit records for successful/unsuccessful uses of the delete_module syscall.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109887</ident><ident system="http://cyber.mil/legacy">V-100783</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21004r305169_fix">Configure the audit system to generate an audit event for any successful/unsuccessful use of the "delete_module" syscall. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S delete_module -F auid&gt;=1000 -F auid!=4294967295 -k module_chng
+-a always,exit -F arch=b64 -S delete_module -F auid&gt;=1000 -F auid!=4294967295 -k module_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command: # sudo augenrules --load</fixtext><fix id="F-21004r305169_fix" /><check system="C-21005r305168_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when successful/unsuccessful attempts to use the "delete_module" syscall.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -w delete_module
+
+-a always,exit -F arch=b32 -S delete_module -F auid&gt;=1000 -F auid!=-1 -k module_chng
+-a always,exit -F arch=b64 -S delete_module -F auid&gt;=1000 -F auid!=-1 -k module_chng
+
+If the command does not return a line that matches the example or the line is commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219281"><title>SRG-OS-000326-GPOS-00126</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219281r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010358</version><title>The Ubuntu operating system must prevent all software from executing at higher privilege levels than users executing the software and the audit system must be configured to audit the execution of privileged functions.</title><description>&lt;VulnDiscussion&gt;In certain situations, software applications/programs need to execute with elevated privileges to perform required functions. However, if the privileges required for execution are at a higher level than the privileges assigned to organizational users invoking such applications/programs, those users are indirectly provided with greater privileges than assigned by the organizations.
+
+Some programs and processes are required to operate at a higher privilege level and therefore should be excluded from the organization-defined software list after review.
+
+Satisfies: SRG-OS-000326-GPOS-00126, SRG-OS-000327-GPOS-00127&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">V-100785</ident><ident system="http://cyber.mil/legacy">SV-109889</ident><ident system="http://cyber.mil/cci">CCI-002233</ident><ident system="http://cyber.mil/cci">CCI-002234</ident><fixtext fixref="F-21005r608752_fix">Configure the Ubuntu operating system to audit the execution of all privileged functions.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -F key=execpriv 
+-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -F key=execpriv 
+-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -F key=execpriv 
+-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -F key=execpriv
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21005r608752_fix" /><check system="C-21006r608751_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system audits the execution of privilege functions by auditing the "execve" system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep execve
+
+-a always,exit -F arch=b64 -S execve -C uid!=euid -F euid=0 -F key=execpriv 
+-a always,exit -F arch=b64 -S execve -C gid!=egid -F egid=0 -F key=execpriv 
+-a always,exit -F arch=b32 -S execve -C uid!=euid -F euid=0 -F key=execpriv 
+-a always,exit -F arch=b32 -S execve -C gid!=egid -F egid=0 -F key=execpriv
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219282"><title>SRG-OS-000462-GPOS-00206</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219282r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010366</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use setxattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109891</ident><ident system="http://cyber.mil/legacy">V-100787</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21006r305175_fix">Configure the audit system to generate audit records for successful/unsuccessful attempts to use setxattr system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b64 -S setxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b32 -S setxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21006r305175_fix" /><check system="C-21007r305174_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records when successful/unsuccessful attempts to use setxattr system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep setxattr
+
+-a always,exit -F arch=b64 -S setxattr -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b32 -S setxattr -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219283"><title>SRG-OS-000462-GPOS-00206</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219283r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010367</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use lsetxattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109893</ident><ident system="http://cyber.mil/legacy">V-100789</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21007r305178_fix">Configure the audit system to generate audit records for successful/unsuccessful attempts to use lsetxattr system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21007r305178_fix" /><check system="C-21008r305177_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records when successful/unsuccessful attempts to use lsetxattr system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep lsetxattr
+
+-a always,exit -F arch=b64 -S lsetxattr -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b32 -S lsetxattr -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219284"><title>SRG-OS-000462-GPOS-00206</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219284r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010368</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use fsetxattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109895</ident><ident system="http://cyber.mil/legacy">V-100791</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21008r305181_fix">Configure the audit system to generate audit records for successful/unsuccessful attempts to use fsetxattr system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21008r305181_fix" /><check system="C-21009r305180_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records when successful/unsuccessful attempts to use fsetxattr system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep fsetxattr
+
+-a always,exit -F arch=b64 -S fsetxattr -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b32 -S fsetxattr -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219285"><title>SRG-OS-000462-GPOS-00206</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219285r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010369</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use the removexattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000462-GPOS-00206, SRG-OS-000466-GPOS-00210&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109897</ident><ident system="http://cyber.mil/legacy">V-100793</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21009r305184_fix">Configure the audit system to generate audit records for successful/unsuccessful attempts to use removexattr system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b64 -S removexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b32 -S removexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21009r305184_fix" /><check system="C-21010r305183_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records when successful/unsuccessful attempts to use removexattr system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep removexattr
+
+-a always,exit -F arch=b64 -S removexattr -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b32 -S removexattr -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219286"><title>SRG-OS-000462-GPOS-00206</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219286r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010370</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use the lremovexattr system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000462-GPOS-00206, SRG-OS-000466-GPOS-00210&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109899</ident><ident system="http://cyber.mil/legacy">V-100795</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21010r305187_fix">Configure the audit system to generate audit records for successful/unsuccessful attempts to use lremovexattr system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;=1000 -F auid!=4294967295 -k perm_chng
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21010r305187_fix" /><check system="C-21011r305186_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records when successful/unsuccessful attempts to use lremovexattr system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep lremovexattr
+
+-a always,exit -F arch=b64 -S lremovexattr -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+-a always,exit -F arch=b32 -S lremovexattr -F auid&gt;=1000 -F auid!=-1 -k perm_chng
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Note: 
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219287"><title>SRG-OS-000468-GPOS-00212</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219287r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010375</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful use of unlink system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109901</ident><ident system="http://cyber.mil/legacy">V-100797</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21011r305190_fix">Configure the audit system to generate audit events when successful/unsuccessful use of unlink system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b64 -S unlink -Fauid&gt;=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlink -F auid&gt;=1000 -F auid!=4294967295 -k delete
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21011r305190_fix" /><check system="C-21012r305189_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records when successful/unsuccessful use of unlink system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep unlink
+
+-a always,exit -F arch=b64 -S unlink -F auid&gt;=1000 -F auid!=-1 -k delete
+-a always,exit -F arch=b32 -S unlink -F auid&gt;=1000 -F auid!=-1 -k delete
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219288"><title>SRG-OS-000468-GPOS-00212</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219288r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010376</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful use of unlinkat system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109903</ident><ident system="http://cyber.mil/legacy">V-100799</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21012r305193_fix">Configure the audit system to generate audit events when successful/unsuccessful use of the unlinkat system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b64 -S unlinkat -Fauid&gt;=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S unlinkat -F auid&gt;=1000 -F auid!=4294967295 -k delete
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21012r305193_fix" /><check system="C-21013r305192_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records when successful/unsuccessful use of unlinkat system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep unlinkat
+
+-a always,exit -F arch=b64 -S unlinkat -F auid&gt;=1000 -F auid!=-1 -k delete
+-a always,exit -F arch=b32 -S unlinkat -F auid&gt;=1000 -F auid!=-1 -k delete
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219289"><title>SRG-OS-000468-GPOS-00212</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219289r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010377</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful use of rename system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109905</ident><ident system="http://cyber.mil/legacy">V-100801</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21013r305196_fix">Configure the audit system to generate audit events when successful/unsuccessful use of the rename system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b64 -S rename -Fauid&gt;=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S rename -F auid&gt;=1000 -F auid!=4294967295 -k delete
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21013r305196_fix" /><check system="C-21014r305195_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records when successful/unsuccessful use of rename system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep rename
+
+-a always,exit -F arch=b64 -S rename -F auid&gt;=1000 -F auid!=-1 -k delete
+-a always,exit -F arch=b32 -S rename -F auid&gt;=1000 -F auid!=-1 -k delete
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219290"><title>SRG-OS-000468-GPOS-00212</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219290r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010378</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful use of renameat system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109907</ident><ident system="http://cyber.mil/legacy">V-100803</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21014r305199_fix">Configure the audit system to generate audit events when successful/unsuccessful use of the renameat system call.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b64 -S renameat -Fauid&gt;=1000 -F auid!=4294967295 -k delete
+-a always,exit -F arch=b32 -S renameat -F auid&gt;=1000 -F auid!=4294967295 -k delete
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21014r305199_fix" /><check system="C-21015r305198_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates audit records when successful/unsuccessful use of renameat system call.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep renameat
+
+-a always,exit -F arch=b64 -S renameat -F auid&gt;=1000 -F auid!=-1 -k delete
+-a always,exit -F arch=b32 -S renameat -F auid&gt;=1000 -F auid!=-1 -k delete
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219291"><title>SRG-OS-000471-GPOS-00216</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219291r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010379</version><title>The Ubuntu operating system must generate audit records when loading dynamic kernel modules.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109909</ident><ident system="http://cyber.mil/legacy">V-100805</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21015r569473_fix">Configure the audit system to generate audit events when adding and deleting kernel modules.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S init_module -S finit_module -k modules
+-a always,exit -F arch=b64 -S init_module -S finit_module -k modules
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21015r569473_fix" /><check system="C-21016r569472_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when adding and deleting kernel modules.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -E 'init_module|finit_module' 
+
+-a always,exit -F arch=b32 -S init_module -S finit_module -k modules
+-a always,exit -F arch=b64 -S init_module -S finit_module -k modules
+
+If the command does not return lines that matches the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219292"><title>SRG-OS-000471-GPOS-00216</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219292r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010380</version><title>The Ubuntu operating system must generate audit records when unloading dynamic kernel modules.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one. 
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109911</ident><ident system="http://cyber.mil/legacy">V-100807</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21016r569476_fix">Configure the audit system to generate audit events when adding and deleting kernel modules.
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S delete_module -k modules
+-a always,exit -F arch=b64 -S delete_module -k modules
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21016r569476_fix" /><check system="C-21017r569475_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when adding and deleting kernel modules.
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep -delete_module 
+
+-a always,exit -F arch=b32 -S delete_module -k modules
+-a always,exit -F arch=b64 -S delete_module -k modules
+
+If the command does not return lines that matches the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219293"><title>SRG-OS-000474-GPOS-00219</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219293r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010382</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful uses of the truncate system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109913</ident><ident system="http://cyber.mil/legacy">V-100809</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21017r569479_fix">Configure the audit system to generate an audit event for any unsuccessful use of the "truncate" system call. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21017r569479_fix" /><check system="C-21018r569478_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when unsuccessful attempts to use the "truncate" system call occur.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep truncate
+-a always,exit -F arch=b32 -S truncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b32 -S truncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S truncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S truncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219294"><title>SRG-OS-000474-GPOS-00219</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219294r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010383</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful uses of the ftruncate system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109915</ident><ident system="http://cyber.mil/legacy">V-100811</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21018r569482_fix">Configure the audit system to generate an audit event for any unsuccessful use of the "ftruncate" system call. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21018r569482_fix" /><check system="C-21019r569481_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when unsuccessful attempts to use the "ftruncate" system call.
+
+Check the configured audit rules with the following command:
+
+# sudo auditctl -l | grep ftruncate
+
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b32 -S ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S ftruncate -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219295"><title>SRG-OS-000474-GPOS-00219</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219295r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010384</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful uses of the creat system call.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).
+
+Satisfies: SRG-OS-000064-GPOS-00033&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109917</ident><ident system="http://cyber.mil/legacy">V-100813</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21019r569485_fix">Configure the audit system to generate an audit event for any unsuccessful use of the "creat" system call. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid&gt;=1000 -F auid!=4294967295 -k perm_access
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21019r569485_fix" /><check system="C-21020r569484_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system generates an audit record when unsuccessful attempts to use the "creat" system call.
+
+Check the configured audit rules with the following commands:
+
+# sudo auditctl -l | grep creat
+
+-a always,exit -F arch=b32 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b32 -S creat -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S creat -F exit=-EPERM -F auid&gt;=1000 -F auid!=-1 -k perm_access
+-a always,exit -F arch=b64 -S creat -F exit=-EACCES -F auid&gt;=1000 -F auid!=-1 -k perm_access
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219296"><title>SRG-OS-000477-GPOS-00222</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219296r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010387</version><title>The Ubuntu operating system must generate records for successful/unsuccessful uses of init_module or finit_module syscalls.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109919</ident><ident system="http://cyber.mil/legacy">V-100815</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21020r305217_fix">Configure the audit system to generate an audit event for any use of the "init_module" or "finit_module" system calls. 
+
+Add or update the following rules in the "/etc/audit/rules.d/stig.rules" file:
+
+-a always,exit -F arch=b32 -S init_module -S finit_module -F key=modules
+-a always,exit -F arch=b64 -S init_module -S finit_module -F key=modules
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21020r305217_fix" /><check system="C-21021r305216_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system is configured to audit the "init_module" and "finit_module" syscalls, by running the following command:
+
+# sudo auditctl -l | grep -E 'init_module|finit_module'
+
+-a always,exit -F arch=b64 -S init_module -S finit_module -F key=modules
+-a always,exit -F arch=b32 -S init_module -S finit_module -F key=modules
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219297"><title>SRG-OS-000477-GPOS-00222</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219297r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010388</version><title>The Ubuntu operating system must generate records for successful/unsuccessful uses of delete_module syscall.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109921</ident><ident system="http://cyber.mil/legacy">V-100817</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21021r305220_fix">Configure the Ubuntu operating system to generate an audit event for any use of the delete_module system call.
+
+Add or update the following rule in the "/etc/audit/rules.d/stig.rules" file.
+
+-a always,exit -F arch=b32 -S delete_module -F key=modules
+-a always,exit -F arch=b64 -S delete_module -F key=modules
+
+Notes: For 32-bit architectures, only the 32-bit specific entries are required. 
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21021r305220_fix" /><check system="C-21022r305219_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system is configured to audit the "delete_module" syscall, by running the following command:
+
+# sudo auditctl -l | egrep delete_module
+
+-a always,exit -F arch=b64 -S delete_module -F key=modules
+-a always,exit -F arch=b32 -S delete_module -F key=modules
+
+If the command does not return lines that match the example or the lines are commented out, this is a finding.
+
+Notes:
+For 32-bit architectures, only the 32-bit specific output lines from the commands are required.
+The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219298"><title>SRG-OS-000477-GPOS-00222</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219298r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010389</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use modprobe command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109923</ident><ident system="http://cyber.mil/legacy">V-100819</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21022r305223_fix">Configure the Ubuntu operating system to audit the execution of the module management program "modprobe".
+
+Add or update the following rule in the "/etc/audit/rules.d/stig.rules" file.
+
+-w /sbin/modprobe -p x -k modules
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21022r305223_fix" /><check system="C-21023r305222_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system is configured to audit the execution of the module management program "modprobe", by running the following command:
+
+sudo auditctl -l | grep "/sbin/modprobe"
+
+-w /sbin/modprobe -p x -k modules
+
+If the command does not return a line, or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219299"><title>SRG-OS-000477-GPOS-00222</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219299r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010391</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use the kmod command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109925</ident><ident system="http://cyber.mil/legacy">V-100821</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21023r305226_fix">Configure the Ubuntu operating system to audit the execution of the module management program "kmod".
+
+Add or update the following rule in the "/etc/audit/rules.d/stig.rules" file.
+
+-w /bin/kmod -p x -k modules
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21023r305226_fix" /><check system="C-21024r305225_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system is configured to audit the execution of the module management program "kmod".
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep kmod
+
+-w /bin/kmod -p x -k module
+
+If the command does not return a line, or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219300"><title>SRG-OS-000477-GPOS-00222</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219300r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010392</version><title>The Ubuntu operating system must generate audit records when successful/unsuccessful attempts to use the fdisk command.</title><description>&lt;VulnDiscussion&gt;Without generating audit records that are specific to the security and mission needs of the organization, it would be difficult to establish, correlate, and investigate the events relating to an incident or identify those responsible for one.
+
+Audit records can be generated from various components within the information system (e.g., module or policy filter).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109927</ident><ident system="http://cyber.mil/legacy">V-100823</ident><ident system="http://cyber.mil/cci">CCI-000172</ident><fixtext fixref="F-21024r305229_fix">Configure the Ubuntu operating system to audit the execution of the partition management program "fdisk".
+
+Add or update the following rule in the "/etc/audit/rules.d/stig.rules" file.
+
+-w /bin/fdisk -p x -k fdisk
+
+Note:
+The "root" account must be used to view/edit any files in the /etc/audit/rules.d/ directory.
+
+In order to reload the rules file, issue the following command:
+
+# sudo augenrules --load</fixtext><fix id="F-21024r305229_fix" /><check system="C-21025r305228_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify if the Ubuntu operating system is configured to audit the execution of the partition management program "fdisk".
+
+Check the currently configured audit rules with the following command:
+
+# sudo auditctl -l | grep fdisk
+
+-w /sbin/fdisk -p x -k fdisk
+
+If the command does not return a line, or the line is commented out, this is a finding.
+
+Note: The '-k' allows for specifying an arbitrary identifier and the string after it does not need to match the example output above.</check-content></check></Rule></Group><Group id="V-219301"><title>SRG-OS-000027-GPOS-00008</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219301r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010400</version><title>The Ubuntu operating system must limit the number of concurrent sessions to ten for all accounts and/or account types.</title><description>&lt;VulnDiscussion&gt;Ubuntu operating system management includes the ability to control the number of users and user sessions that utilize an operating system. Limiting the number of allowed users and sessions per user is helpful in reducing the risks related to DoS attacks.
+
+This requirement addresses concurrent sessions for information system accounts and does not address concurrent sessions by single users via multiple system accounts. The maximum number of concurrent sessions should be defined based on mission needs and the operational environment for each system.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109929</ident><ident system="http://cyber.mil/legacy">V-100825</ident><ident system="http://cyber.mil/cci">CCI-000054</ident><fixtext fixref="F-21025r305232_fix">Configure the Ubuntu operating system to limit the number of concurrent sessions to ten for all accounts and/or account types.
+
+Add the following line to the top of the /etc/security/limits.conf:
+
+* hard maxlogins 10</fixtext><fix id="F-21025r305232_fix" /><check system="C-21026r305231_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system limits the number of concurrent sessions to ten for all accounts and/or account types by running the following command:
+
+# grep maxlogins /etc/security/limits.conf | grep -v '^* hard maxlogins'
+
+The result must contain the following line:
+
+* hard maxlogins 10
+
+If the "maxlogins" item is missing or the value is not set to 10 or less, it is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219302"><title>SRG-OS-000028-GPOS-00009</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219302r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010401</version><title>The Ubuntu operating system must retain a users session lock until that user reestablishes access using established identification and authentication procedures.</title><description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
+
+The session lock is implemented at the point where session activity can be determined. Rather than be forced to wait for a period of time to expire before the user session can be locked, Ubuntu operating systems need to provide users with the ability to manually invoke a session lock so users may secure their session should the need arise for them to temporarily vacate the immediate physical vicinity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109931</ident><ident system="http://cyber.mil/legacy">V-100827</ident><ident system="http://cyber.mil/cci">CCI-000056</ident><fixtext fixref="F-21026r305235_fix">Configure the Ubuntu operating system so that it allows a user to lock the current graphical user interface session.
+
+Note: If the Ubuntu operating system does not have a Graphical User Interface installed, this requirement is Not Applicable.
+
+Set the ""lock-enabled"" setting to allow graphical user interface session locks with the following command: 
+
+# sudo gsettings set org.gnome.desktop.screensaver lock-enabled true</fixtext><fix id="F-21026r305235_fix" /><check system="C-21027r305234_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operation system has a graphical user interface session lock enabled.
+
+Note: If the Ubuntu operating system does not have a Graphical User Interface installed, this requirement is Not Applicable.
+
+Get the ""lock-enabled"" setting to verify if the graphical user interface session has the lock enabled with the following command: 
+
+# sudo gsettings get org.gnome.desktop.screensaver lock-enabled
+
+true
+
+If "lock-enabled" is not set to "true", this is a finding.</check-content></check></Rule></Group><Group id="V-219303"><title>SRG-OS-000029-GPOS-00010</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219303r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010402</version><title>The Ubuntu operating system must initiate a session lock after a 15-minute period of inactivity for all connection types.</title><description>&lt;VulnDiscussion&gt;A session time-out lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not log out because of the temporary nature of the absence. Rather than relying on the user to manually lock their operating system session prior to vacating the vicinity, the Ubuntu operating system need to be able to identify when a user's session has idled and take action to initiate the session lock.
+
+The session lock is implemented at the point where session activity can be determined and/or controlled.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109933</ident><ident system="http://cyber.mil/legacy">V-100829</ident><ident system="http://cyber.mil/cci">CCI-000057</ident><fixtext fixref="F-21027r305238_fix">Configure the Ubuntu operating system to initiate a session logout after a 15-minute period of inactivity. 
+
+Create a file to contain the system-wide session auto logout script (if it does not already exist) with the following command:
+
+# sudo touch /etc/profile.d/autologout.sh
+
+Add the following lines to the "/etc/profile.d/autologout.sh" script:
+
+TMOUT=900
+readonly TMOUT
+export TMOUT</fixtext><fix id="F-21027r305238_fix" /><check system="C-21028r305237_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system initiates a session logout after a 15-minute period of inactivity. 
+
+Check that the proper auto logout script exists with the following command:
+
+# cat /etc/profile.d/autologout.sh
+TMOUT=900
+readonly TMOUT
+export TMOUT
+
+If the file "/etc/profile.d/autologout.sh" does not exist with the contents shown above, the value of "TMOUT" is greater than 900, or the timeout values are commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219304"><title>SRG-OS-000030-GPOS-00011</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219304r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010403</version><title>The Ubuntu operating system must be configured for users to directly initiate a session lock for all connection types.</title><description>&lt;VulnDiscussion&gt;A session lock is a temporary action taken when a user stops work and moves away from the immediate physical vicinity of the information system but does not want to log out because of the temporary nature of the absence.
+
+The session lock is implemented at the point where session activity can be determined. Rather than be forced to wait for a period of time to expire before the user session can be locked, the Ubuntu operating system need to provide users with the ability to manually invoke a session lock so users may secure their session should the need arise for them to temporarily vacate the immediate physical vicinity.
+
+Satisfies: SRG-OS-000030-GPOS-00011, SRG-OS-000031-GPOS-00012&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109935</ident><ident system="http://cyber.mil/legacy">V-100831</ident><ident system="http://cyber.mil/cci">CCI-000058</ident><ident system="http://cyber.mil/cci">CCI-000060</ident><fixtext fixref="F-21028r305241_fix">Install the "vlock" (if it is not already installed) package by running the following command:
+
+# sudo apt-get install vlock</fixtext><fix id="F-21028r305241_fix" /><check system="C-21029r305240_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system has the 'vlock' package installed, by running the following command:
+
+# dpkg -l | grep vlock
+
+If "vlock" is not installed, this is a finding.</check-content></check></Rule></Group><Group id="V-219306"><title>SRG-OS-000032-GPOS-00013</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219306r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010410</version><title>The Ubuntu operating system must monitor remote access methods.</title><description>&lt;VulnDiscussion&gt;Remote access services, such as those providing remote access to network devices and information systems, which lack automated monitoring capabilities, increase risk and make remote user access management difficult at best.
+
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+Automated monitoring of remote access sessions allows organizations to detect cyber attacks and also ensure ongoing compliance with remote access policies by auditing connection activities of remote access capabilities, such as Remote Desktop Protocol (RDP), on a variety of information system components (e.g., servers, workstations, notebook computers, smartphones, and tablets).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109939</ident><ident system="http://cyber.mil/legacy">V-100835</ident><ident system="http://cyber.mil/cci">CCI-000067</ident><fixtext fixref="F-21030r305247_fix">Configure the Ubuntu operating system to monitor all remote access methods by adding the following lines to the "/etc/rsyslog.d/50-default.conf" file:
+
+auth.*,authpriv.* /var/log/secure
+daemon.notice /var/log/messages
+
+In order for the changes to take effect the "rsyslog" service must be restarted with the following command:
+
+# sudo systemctl restart rsyslog.service</fixtext><fix id="F-21030r305247_fix" /><check system="C-21031r305246_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system monitors all remote access methods.
+
+Check that remote access methods are being logged by running the following command:
+
+# grep -E -r '^(auth,authpriv\.\*|daemon\.\*)' /etc/rsyslog.*
+/etc/rsyslog.d/50-default.conf:auth,authpriv.* /var/log/auth.log
+/etc/rsyslog.d/50-default.conf:daemon.notice /var/log/messages
+
+If "auth.*", "authpriv.*" or "daemon.*" are not configured to be logged in at least one of the config files, this is a finding.</check-content></check></Rule></Group><Group id="V-219307"><title>SRG-OS-000033-GPOS-00014</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219307r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010411</version><title>The Ubuntu operating system must implement DoD-approved encryption to protect the confidentiality of remote access sessions.</title><description>&lt;VulnDiscussion&gt;Without confidentiality protection mechanisms, unauthorized individuals may gain access to sensitive information via a remote access session.
+
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+Encryption provides a means to secure the remote connection to prevent unauthorized access to the data traversing the remote access connection (e.g., RDP), thereby providing a degree of confidentiality. The encryption strength of a mechanism is selected based on the security categorization of the information.
+
+By specifying a cipher list with the order of ciphers being in a “strongest to weakest” orientation, the system will automatically attempt to use the strongest cipher for securing SSH connections.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109941</ident><ident system="http://cyber.mil/legacy">V-100837</ident><ident system="http://cyber.mil/cci">CCI-000068</ident><fixtext fixref="F-21031r608755_fix">Configure the Ubuntu operating system to allow the SSH daemon to only implement DoD-approved encryption.
+
+Add the following line (or modify the line to have the required value) to the "/etc/ssh/sshd_config" file (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor):
+
+Ciphers aes256-ctr,aes192-ctr,aes128-ctr
+
+In order for the changes to take effect, the SSH daemon must be restarted.
+
+# sudo systemctl restart sshd.service</fixtext><fix id="F-21031r608755_fix" /><check system="C-21032r608754_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the SSH daemon is configured to only implement DoD-approved encryption.
+
+Check the SSH daemon's current configured ciphers by running the following command:
+
+# grep -E '^Ciphers ' /etc/ssh/sshd_config
+
+Ciphers aes256-ctr,aes192-ctr, aes128-ctr
+
+If any ciphers other than "aes256-ctr", "aes192-ctr", or "aes128-ctr" are listed, the order differs from the example above, the "Ciphers" keyword is missing, or the returned line is commented out, this is a finding.
+</check-content></check></Rule></Group><Group id="V-219308"><title>SRG-OS-000112-GPOS-00057</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219308r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010412</version><title>The Ubuntu operating system must enforce SSHv2 for network access to all accounts.</title><description>&lt;VulnDiscussion&gt;A replay attack may enable an unauthorized user to gain access to the operating system. Authentication sessions between the authenticator and the operating system validating the user credentials must not be vulnerable to a replay attack.
+
+An authentication process resists replay attacks if it is impractical to achieve a successful authentication by recording and replaying a previous authentication message.
+
+A privileged account is any information system account with authorizations of a privileged user.
+
+Techniques used to address this include protocols using nonces (e.g., numbers generated for a specific one-time use) or challenges (e.g., TLS, WS_Security). Additional techniques include time-synchronous or challenge-response one-time authenticators.
+
+Satisfies: SRG-OS-000112-GPOS-00057, SRG-OS-000113-GPOS-00058&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109943</ident><ident system="http://cyber.mil/legacy">V-100839</ident><ident system="http://cyber.mil/cci">CCI-001941</ident><ident system="http://cyber.mil/cci">CCI-001942</ident><fixtext fixref="F-21032r305253_fix">Configure the Ubuntu operating system to enforce SSHv2 for network access to all accounts.
+
+Add or update the following line in the "/etc/ssh/sshd_config" file:
+
+Protocol 2
+
+Restart the ssh service.
+
+# systemctl restart sshd.service</fixtext><fix id="F-21032r305253_fix" /><check system="C-21033r305252_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system enforces SSH protocol 2 for network access.
+
+Check the protocol versions that SSH allows with the following command:
+
+# grep Protocol /etc/ssh/sshd_config
+
+Protocol 2
+
+If the returned line allows for use of protocol "1", is commented out, or the line is missing, this is a finding.</check-content></check></Rule></Group><Group id="V-219309"><title>SRG-OS-000125-GPOS-00065</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219309r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010414</version><title>The Ubuntu operating system must use strong authenticators in establishing nonlocal maintenance and diagnostic sessions.</title><description>&lt;VulnDiscussion&gt;Nonlocal maintenance and diagnostic activities are those activities conducted by individuals communicating through a network, either an external network (e.g., the Internet) or an internal network. Local maintenance and diagnostic activities are those activities carried out by individuals physically present at the information system or information system component and not communicating across a network connection. Typically, strong authentication requires authenticators that are resistant to replay attacks and employ multifactor authentication. Strong authenticators include, for example, PKI where certificates are stored on a token protected by a password, passphrase, or biometric.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109945</ident><ident system="http://cyber.mil/legacy">V-100841</ident><ident system="http://cyber.mil/cci">CCI-000877</ident><fixtext fixref="F-21033r305256_fix">Configure the Ubuntu operating system to use strong authentication when establishing nonlocal maintenance and diagnostic sessions. 
+
+Add or modify the following line to /etc/ssh/sshd_config
+
+UsePAM yes</fixtext><fix id="F-21033r305256_fix" /><check system="C-21034r305255_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is configured to use strong authenticators in the establishment of nonlocal maintenance and diagnostic maintenance.
+
+Check that "UsePAM" is set to yes in /etc/ssh/sshd_config:
+
+# grep UsePAM /etc/ssh/sshd_config
+
+UsePAM yes
+
+If "UsePAM" is not set to "yes", this is a finding.</check-content></check></Rule></Group><Group id="V-219310"><title>SRG-OS-000126-GPOS-00066</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219310r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010415</version><title>The Ubuntu operating system must immediately terminate all network connections associated with SSH traffic after a period of inactivity.</title><description>&lt;VulnDiscussion&gt;Automatic session termination addresses the termination of user-initiated logical sessions in contrast to the termination of network connections that are associated with communications sessions (i.e., network disconnect). A logical session (for local, network, and remote access) is initiated whenever a user (or process acting on behalf of a user) accesses an organizational information system. Such user sessions can be terminated (and thus terminate user access) without terminating network sessions.
+
+Session termination terminates all processes associated with a user's logical session except those processes that are specifically created by the user (i.e., session owner) to continue after the session is terminated.
+
+Conditions or trigger events requiring automatic session termination can include, for example, organization-defined periods of user inactivity, targeted responses to certain types of incidents, and time-of-day restrictions on information system use.
+
+This capability is typically reserved for specific Ubuntu operating system functionality where the system owner, data owner, or organization requires additional assurance.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109947</ident><ident system="http://cyber.mil/legacy">V-100843</ident><ident system="http://cyber.mil/cci">CCI-000879</ident><fixtext fixref="F-21034r305259_fix">Configure the Ubuntu operating system to automatically terminate inactive SSH sessions after a period of inactivity.
+
+Modify or append the following line in the "/etc/ssh/sshd_config" file replacing "[Count]" with a value of 1:
+
+ClientAliveCountMax 1
+
+In order for the changes to take effect, the SSH daemon must be restarted.
+
+# sudo systemctl restart sshd.service</fixtext><fix id="F-21034r305259_fix" /><check system="C-21035r305258_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that all network connections associated with SSH traffic automatically terminate after a period of inactivity.
+
+Check that "ClientAliveCountMax" variable is set in "/etc/ssh/sshd_config" file by performing the following command:
+
+# sudo grep -i clientalivecountmax /etc/ssh/sshd_config
+
+ClientAliveCountMax 1
+
+If "ClientAliveCountMax" is not set, or not set to "1", or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219311"><title>SRG-OS-000163-GPOS-00072</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219311r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010416</version><title>The Ubuntu operating system must automatically terminate all network connections associated with SSH traffic at the end of the session or after 10 minutes of inactivity.</title><description>&lt;VulnDiscussion&gt;Automatic session termination addresses the termination of user-initiated logical sessions in contrast to the termination of network connections that are associated with communications sessions (i.e., network disconnect). A logical session (for local, network, and remote access) is initiated whenever a user (or process acting on behalf of a user) accesses an organizational information system. Such user sessions can be terminated (and thus terminate user access) without terminating network sessions.
+
+Session termination terminates all processes associated with a user's logical session except those processes that are specifically created by the user (i.e., session owner) to continue after the session is terminated.
+
+Terminating an idle session within a short time period reduces the window of opportunity for unauthorized personnel to take control of a management session enabled on the console or console port that has been left unattended. In addition, quickly terminating an idle session will also free up resources committed by the managed network element. 
+
+Terminating network connections associated with communications sessions includes, for example, de-allocating associated TCP/IP address/port pairs at the operating system level, and de-allocating networking assignments at the application level if multiple application sessions are using a single operating system-level network connection. This does not mean that the operating system terminates all sessions or network access; it only ends the inactive session and releases the resources associated with that session.
+
+Conditions or trigger events requiring automatic session termination can include, for example, organization-defined periods of user inactivity, targeted responses to certain types of incidents, and time-of-day restrictions on information system use.
+
+Satisfies: SRG-OS-000279-GPOS-00109&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">V-100845</ident><ident system="http://cyber.mil/legacy">SV-109949</ident><ident system="http://cyber.mil/cci">CCI-001133</ident><ident system="http://cyber.mil/cci">CCI-002361</ident><fixtext fixref="F-21035r569463_fix">Configure the Ubuntu operating system to automatically terminate all network connections associated with SSH traffic at the end of a session or after a 10 minute period of inactivity.
+
+Modify or append the following line in the "/etc/ssh/sshd_config" file replacing "[Interval]" with a value of "600" or less:
+
+ClientAliveInterval 600
+
+In order for the changes to take effect, the SSH daemon must be restarted.
+
+# sudo systemctl restart sshd.service</fixtext><fix id="F-21035r569463_fix" /><check system="C-21036r569462_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that all network connections associated with SSH traffic are automatically terminated at the end of the session or after 10 minutes of inactivity.
+
+Check that the "ClientAliveInterval" variable is set to a value of "600" or less by performing the following command:
+
+# sudo grep -i clientalive /etc/ssh/sshd_config
+
+ClientAliveInterval 600
+
+If "ClientAliveInterval" does not exist, is not set to a value of "600" or less in "/etc/ssh/sshd_config", or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219312"><title>SRG-OS-000250-GPOS-00093</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219312r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010417</version><title>The Ubuntu operating system must configure the SSH daemon to only use Message Authentication Codes (MACs) employing FIPS 140-2 approved cryptographic hash algorithms to protect the integrity of nonlocal maintenance and diagnostic communications.</title><description>&lt;VulnDiscussion&gt;Without cryptographic integrity protections, information can be altered by unauthorized users without detection.
+
+Nonlocal maintenance and diagnostic activities are those activities conducted by individuals communicating through a network, either an external network (e.g., the Internet) or an internal network. Local maintenance and diagnostic activities are those activities carried out by individuals physically present at the information system or information system component and not communicating across a network connection.
+
+Remote access (e.g., RDP) is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+Cryptographic mechanisms used for protecting the integrity of information include, for example, signed hash functions using asymmetric cryptography enabling distribution of the public key to verify the hash information while maintaining the confidentiality of the secret key used to generate the hash.
+
+Satisfies: SRG-OS-000250-GPOS-00093, SRG-OS-000393-GPOS-00173, SRG-OS-000394-GPOS-00174&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109951</ident><ident system="http://cyber.mil/legacy">V-100847</ident><ident system="http://cyber.mil/cci">CCI-002890</ident><ident system="http://cyber.mil/cci">CCI-003123</ident><ident system="http://cyber.mil/cci">CCI-001453</ident><fixtext fixref="F-21036r608758_fix">Configure the Ubuntu operating system to allow the SSH daemon to only use Message Authentication Codes (MACs) that employ FIPS 140-2 approved ciphers.
+
+Add the following line (or modify the line to have the required value) to the "/etc/ssh/sshd_config" file (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor):
+
+MACs hmac-sha2-512,hmac-sha2-256
+
+In order for the changes to take effect, reload the SSH daemon.
+
+# sudo systemctl reload sshd.service</fixtext><fix id="F-21036r608758_fix" /><check system="C-21037r608757_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system configures the SSH daemon to only use Message Authentication Codes (MACs) that employ FIPS 140-2 approved ciphers.
+
+Check that the SSH daemon is configured to only use MACs that employ FIPS 140-2 approved ciphers with the following command:
+
+# sudo grep -i macs /etc/ssh/sshd_config
+
+MACs hmac-sha2-512,hmac-sha2-256
+
+If any ciphers other than "hmac-sha2-512" or "hmac-sha2-256" are listed, the order differs from the example above, or the returned line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219313"><title>SRG-OS-000423-GPOS-00187</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219313r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010420</version><title>The Ubuntu operating system must use SSH to protect the confidentiality and integrity of transmitted information unless otherwise protected by alternative physical safeguards, such as, at a minimum, a Protected Distribution System (PDS).</title><description>&lt;VulnDiscussion&gt;Without protection of the transmitted information, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read or altered. 
+
+This requirement applies to both internal and external networks and all types of information system components from which information can be transmitted (e.g., servers, mobile devices, notebook computers, printers, copiers, scanners, and facsimile machines). Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification. 
+
+Protecting the confidentiality and integrity of organizational information can be accomplished by physical means (e.g., employing physical distribution systems) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, then logical means (cryptography) do not have to be employed, and vice versa.
+
+Alternative physical protection measures include PDS. PDSs are used to transmit unencrypted classified National Security Information (NSI) through an area of lesser classification or control. Since the classified NSI is unencrypted, the PDS must provide adequate electrical, electromagnetic, and physical safeguards to deter exploitation.
+
+Satisfies: SRG-OS-000423-GPOS-00187, SRG-OS-000424-GPOS-00188, SRG-OS-000425-GPOS-00189, SRG-OS-000426-GPOS-00190&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109953</ident><ident system="http://cyber.mil/legacy">V-100849</ident><ident system="http://cyber.mil/cci">CCI-002418</ident><ident system="http://cyber.mil/cci">CCI-002420</ident><ident system="http://cyber.mil/cci">CCI-002421</ident><ident system="http://cyber.mil/cci">CCI-002422</ident><fixtext fixref="F-21037r305268_fix">Install the "ssh" meta-package on the system with the following command:
+
+# sudo apt install ssh
+
+Enable the "ssh" service to start automatically on reboot with the following command:
+
+# sudo systemctl enable sshd.service
+
+Ensure that the "ssh" service is running.
+
+# sudo systemctl start sshd.service</fixtext><fix id="F-21037r305268_fix" /><check system="C-21038r305267_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Check that the ssh package is installed with the following command:
+
+# sudo dpkg -l | grep openssh
+ii openssh-client 1:7.6p1-4ubuntu0.1 amd64 secure shell (SSH) client, for secure access to remote machines
+ii openssh-server 1:7.6p1-4ubuntu0.1 amd64 secure shell (SSH) server, for secure access from remote machines
+ii openssh-sftp-server 1:7.6p1-4ubuntu0.1 amd64 secure shell (SSH) sftp server module, for SFTP access from remote machines
+
+If the "openssh" server package is not installed, this is a finding.
+
+Check that the "sshd.service" is loaded and active with the following command:
+
+# sudo systemctl status sshd.service | egrep -i "(active|loaded)"
+ Loaded: loaded (/lib/systemd/system/ssh.service; enabled; vendor preset: enabled)
+ Active: active (running) since Thu 2019-01-24 22:52:58 UTC; 1 weeks 3 days ago
+
+If "sshd.service" is not active or loaded, this is a finding.</check-content></check></Rule></Group><Group id="V-219314"><title>SRG-OS-000480-GPOS-00229</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219314r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010424</version><title>The Ubuntu operating system must not allow unattended or automatic login via ssh.</title><description>&lt;VulnDiscussion&gt;Failure to restrict system access to authenticated users negatively impacts Ubuntu operating system security.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109955</ident><ident system="http://cyber.mil/legacy">V-100851</ident><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-21038r305271_fix">Configure the Ubuntu operating system to allow the SSH daemon to not allow unattended or automatic login to the system.
+
+Add or edit the following lines in the "/etc/ssh/sshd_config" file:
+
+PermitEmptyPasswords no
+PermitUserEnvironment no
+
+In order for the changes to take effect, the SSH daemon must be restarted.
+
+# sudo systemctl restart sshd.service</fixtext><fix id="F-21038r305271_fix" /><check system="C-21039r305270_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that unattended or automatic login via ssh is disabled.
+
+Check that unattended or automatic login via ssh is disabled with the following command:
+
+# egrep '(Permit(.*?)(Passwords|Environment))' /etc/ssh/sshd_config
+
+PermitEmptyPasswords no
+PermitUserEnvironment no
+
+If "PermitEmptyPasswords" or "PermitUserEnvironment" keywords are not set to "no", are missing completely, or they are commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219315"><title>SRG-OS-000066-GPOS-00034</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219315r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010425</version><title>The Ubuntu operating system, for PKI-based authentication, must validate certificates by constructing a certification path (which includes status information) to an accepted trust anchor.</title><description>&lt;VulnDiscussion&gt;Without path validation, an informed trust decision by the relying party cannot be made when presented with any certificate not already explicitly trusted.
+
+A trust anchor is an authoritative entity represented via a public key and associated data. It is used in the context of public key infrastructures, X.509 digital certificates, and DNSSEC.
+
+When there is a chain of trust, usually the top entity to be trusted becomes the trust anchor; it can be, for example, a Certification Authority (CA). A certification path starts with the subject certificate and proceeds through a number of intermediate certificates up to a trusted root certificate, typically issued by a trusted CA.
+
+This requirement verifies that a certification path to an accepted trust anchor is used for certificate validation and that the path includes status information. Path validation is necessary for a relying party to make an informed trust decision when presented with any certificate not already explicitly trusted. Status information for certification paths includes certificate revocation lists or online certificate status protocol responses. Validation of the certificate status information is out of scope for this requirement.
+
+Satisfies: SRG-OS-000066-GPOS-00034, SRG-OS-000384-GPOS-00167&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109957</ident><ident system="http://cyber.mil/legacy">V-100853</ident><ident system="http://cyber.mil/cci">CCI-000185</ident><ident system="http://cyber.mil/cci">CCI-001991</ident><fixtext fixref="F-21039r305274_fix">Configure the Ubuntu operating system, for PKI-based authentication, to validate certificates by constructing a certification path to an accepted trust anchor.
+
+Determine which pkcs11 module is being used via the use_pkcs11_module in /etc/pam_pkcs11/pam_pkcs11.conf and ensure "ca" is enabled in "cert_policy".
+
+Add or update the "cert_policy" to ensure "ca" is enabled:
+
+cert_policy = ca,signature,ocsp_on;
+
+If the system is missing an "/etc/pam_pkcs11/" directory and an "/etc/pam_pkcs11/pam_pkcs11.conf", find an example to copy into place and modify accordingly at "/usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example.gz".</fixtext><fix id="F-21039r305274_fix" /><check system="C-21040r305273_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system, for PKI-based authentication, had valid certificates by constructing a certification path to an accepted trust anchor.
+
+Check which pkcs11 module is being used via the use_pkcs11_module in /etc/pam_pkcs11/pam_pkcs11.conf and then ensure "ca" is enabled in "cert_policy" with the following command:
+
+# sudo grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module opensc {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy | grep ca 
+
+cert_policy = ca,signature,ocsp_on;
+
+If "cert_policy" is not set to "ca", or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219316"><title>SRG-OS-000068-GPOS-00036</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219316r610963_rule" severity="high" weight="10.0"><version>UBTU-18-010426</version><title>The Ubuntu operating system must map the authenticated identity to the user or group account for PKI-based authentication.</title><description>&lt;VulnDiscussion&gt;Without mapping the certificate used to authenticate to the user account, the ability to determine the identity of the individual user or group will not be available for forensic analysis.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109959</ident><ident system="http://cyber.mil/legacy">V-100855</ident><ident system="http://cyber.mil/cci">CCI-000187</ident><fixtext fixref="F-21040r305277_fix">Install libpam-pkcs11 package on the system. 
+
+Set use_mappers=pwent in /etc/pam_pkcs11/pam_pkcs11.conf
+
+If the system is missing an "/etc/pam_pkcs11/" directory and an "/etc/pam_pkcs11/pam_pkcs11.conf", find an example to copy into place and modify accordingly at "/usr/share/doc/libpam-pkcs11/examples/pam_pkcs11.conf.example.gz".</fixtext><fix id="F-21040r305277_fix" /><check system="C-21041r305276_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system has the 'libpam-pkcs11’ package installed, by running the following command:
+
+# dpkg -l | grep libpam-pkcs11
+
+If "libpam-pkcs11" is not installed, this is a finding.
+
+Check if use_mappers is set to pwent in /etc/pam_pkcs11/pam_pkcs11.conf file
+# grep use_mappers /etc/pam_pkcs11/pam_pkcs11.conf
+use_mappers = pwent
+
+If ‘use_mappers’ is not found or is not set to pwent this is a finding.</check-content></check></Rule></Group><Group id="V-219317"><title>SRG-OS-000105-GPOS-00052</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219317r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010427</version><title>The Ubuntu operating system must implement smart card logins for multifactor authentication for access to accounts.</title><description>&lt;VulnDiscussion&gt;Without the use of multifactor authentication, the ease of access to privileged functions is greatly increased.
+
+Multifactor authentication requires using two or more factors to achieve authentication.
+
+Factors include: 
+1) something a user knows (e.g., password/PIN);
+2) something a user has (e.g., cryptographic identification device, token); and
+3) something a user is (e.g., biometric).
+
+A privileged account is defined as an information system account with authorizations of a privileged user.
+
+Network access is defined as access to an information system by a user (or a process acting on behalf of a user) communicating through a network (e.g., local area network, wide area network, or the Internet).
+
+The DoD CAC with DoD-approved PKI is an example of multifactor authentication.
+
+Satisfies: SRG-OS-000105-GPOS-00052, SRG-OS-000106-GPOS-00053, SRG-OS-000107-GPOS-00054, SRG-OS-000108-GPOS-00055, SRG-OS-000377-GPOS-00162&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109961</ident><ident system="http://cyber.mil/legacy">V-100857</ident><ident system="http://cyber.mil/cci">CCI-000765</ident><ident system="http://cyber.mil/cci">CCI-000766</ident><ident system="http://cyber.mil/cci">CCI-000767</ident><ident system="http://cyber.mil/cci">CCI-000768</ident><ident system="http://cyber.mil/cci">CCI-001954</ident><fixtext fixref="F-21041r305280_fix">Configure the Ubuntu operating system to use multifactor authentication for local access to accounts.
+
+Add or update "pam_pkcs11.so" in "/etc/pam.d/common-auth" to match the following line:
+
+auth [success=2 default=ignore] pam_pkcs11.so</fixtext><fix id="F-21041r305280_fix" /><check system="C-21042r305279_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system uses multifactor authentication for local access to accounts.
+
+Check that the "pam_pkcs11.so" option is configured in the "/etc/pam.d/common-auth" file with the following command:
+
+# grep pam_pkcs11.so /etc/pam.d/common-auth
+auth [success=2 default=ignore] pam_pkcs11.so
+
+If "pam_pkcs11.so" is not set in "/etc/pam.d/common-auth", this is a finding.</check-content></check></Rule></Group><Group id="V-219318"><title>SRG-OS-000375-GPOS-00160</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219318r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010431</version><title>The Ubuntu operating system must implement multifactor authentication for remote access to privileged accounts in such a way that one of the factors is provided by a device separate from the system gaining access.</title><description>&lt;VulnDiscussion&gt;Using an authentication device, such as a CAC or token that is separate from the information system, ensures that even if the information system is compromised, that compromise will not affect credentials stored on the authentication device.
+
+Multifactor solutions that require devices separate from information systems gaining access include, for example, hardware tokens providing time-based or challenge-response authenticators and smart cards such as the U.S. Government Personal Identity Verification card and the DoD Common Access Card.
+
+A privileged account is defined as an information system account with authorizations of a privileged user.
+
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+This requirement only applies to components where this is specific to the function of the device or has the concept of an organizational user (e.g., VPN, proxy capability). This does not apply to authentication for the purpose of configuring the device itself (management).
+
+Requires further clarification from NIST.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109963</ident><ident system="http://cyber.mil/legacy">V-100859</ident><ident system="http://cyber.mil/cci">CCI-001948</ident><fixtext fixref="F-21042r305283_fix">Configure the Ubuntu operating system to implement multifactor authentication by installing the required packages.
+
+Install the "libpam-pkcs11" package on the system with the following command:
+
+# sudo apt install libpam-pkcs11</fixtext><fix id="F-21042r305283_fix" /><check system="C-21043r305282_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system has the packages required for multifactor authentication installed.
+
+Check for the presence of the packages required to support multifactor authentication with the following commands:
+
+# dpkg -l | grep libpam-pkcs11
+
+ii libpam-pkcs11 0.6.8-4 amd64 Fully featured PAM module for using PKCS#11 smart cards
+
+If the "libpam-pkcs11" package is not installed, this is a finding.</check-content></check></Rule></Group><Group id="V-219319"><title>SRG-OS-000376-GPOS-00161</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219319r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010432</version><title>The Ubuntu operating system must accept Personal Identity Verification (PIV) credentials.</title><description>&lt;VulnDiscussion&gt;The use of PIV credentials facilitates standardization and reduces the risk of unauthorized access.
+
+DoD has mandated the use of the CAC to support identity management and personal authentication for systems covered under Homeland Security Presidential Directive (HSPD) 12, as well as making the CAC a primary component of layered protection for national security systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109965</ident><ident system="http://cyber.mil/legacy">V-100861</ident><ident system="http://cyber.mil/cci">CCI-001953</ident><fixtext fixref="F-21043r305286_fix">Configure the Ubuntu operating system to accept Personal Identity Verification (PIV) credentials.
+
+Install the "opensc-pkcs11" package using the following command:
+
+# sudo apt-get install opensc-pkcs11</fixtext><fix id="F-21043r305286_fix" /><check system="C-21044r305285_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system accepts Personal Identity Verification (PIV) credentials.
+
+Check that the "opensc-pcks11" package is installed on the system with the following command:
+
+# dpkg -l | grep opensc-pkcs11
+
+ii opensc-pkcs11:amd64 0.15.0-1Ubuntu1 amd64 Smart card utilities with support for PKCS#15 compatible cards
+
+If the "opensc-pcks11" package is not installed, this is a finding.</check-content></check></Rule></Group><Group id="V-219320"><title>SRG-OS-000377-GPOS-00162</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219320r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010434</version><title>The Ubuntu operating system must implement certificate status checking for multifactor authentication.</title><description>&lt;VulnDiscussion&gt;The use of PIV credentials facilitates standardization and reduces the risk of unauthorized access.
+
+DoD has mandated the use of the CAC to support identity management and personal authentication for systems covered under Homeland Security Presidential Directive (HSPD) 12, as well as making the CAC a primary component of layered protection for national security systems.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109967</ident><ident system="http://cyber.mil/legacy">V-100863</ident><ident system="http://cyber.mil/cci">CCI-001954</ident><fixtext fixref="F-21044r305289_fix">Configure the Ubuntu operating system to certificate status checking for multifactor authentication.
+
+Modify all of the cert_policy lines in "/etc/pam_pkcs11/pam_pkcs11.conf" to include ocsp_on.</fixtext><fix id="F-21044r305289_fix" /><check system="C-21045r305288_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system implements certificate status checking for multifactor authentication.
+
+Check that certificate status checking for multifactor authentication is implemented with the following command:
+
+# sudo grep use_pkcs11_module /etc/pam_pkcs11/pam_pkcs11.conf | awk '/pkcs11_module opensc {/,/}/' /etc/pam_pkcs11/pam_pkcs11.conf | grep cert_policy | grep ocsp_on
+
+cert_policy = ca,signature,ocsp_on;
+
+If "cert_policy" is not set to "ocsp_on", or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219321"><title>SRG-OS-000403-GPOS-00182</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219321r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010436</version><title>The Ubuntu operating system must only allow the use of DoD PKI-established certificate authorities for verification of the establishment of protected sessions.</title><description>&lt;VulnDiscussion&gt;Untrusted Certificate Authorities (CA) can issue certificates, but they may be issued by organizations or individuals that seek to compromise DoD systems or by organizations with insufficient security controls. If the CA used for verifying the certificate is not a DoD-approved CA, trust of this CA has not been established.
+
+The DoD will only accept PKI-certificates obtained from a DoD-approved internal or external certificate authority. Reliance on CAs for the establishment of secure sessions includes, for example, the use of SSL/TLS certificates.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109969</ident><ident system="http://cyber.mil/legacy">V-100865</ident><ident system="http://cyber.mil/cci">CCI-002470</ident><fixtext fixref="F-21045r305292_fix">Add at least one DOD certificate authority to the '/usr/local/share/ca-certificates' directory, then run the 'update-ca-certificates' command.</fixtext><fix id="F-21045r305292_fix" /><check system="C-21046r305291_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the directory containing the root certificates for the Ubuntu operating system only contains certificate files for DoD PKI-established certificate authorities by iterating over all files in the '/etc/ssl/certs' directory and checking if, at least one, has the subject matching "DOD ROOT CA".
+
+If none is found, this is a finding.</check-content></check></Rule></Group><Group id="V-219322"><title>SRG-OS-000312-GPOS-00122</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219322r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010437</version><title>Pam_Apparmor must be configured to allow system administrators to pass information to any other Ubuntu operating system administrator or user, change security attributes, and to confine all non-privileged users from executing functions to include disabling, circumventing, or altering implemented security safeguards/countermeasures.</title><description>&lt;VulnDiscussion&gt;When discretionary access control policies are implemented, subjects are not constrained with regard to what actions they can take with information for which they have already been granted access. Thus, subjects that have been granted access to information are not prevented from passing (i.e., the subjects have the discretion to pass) the information to other subjects or objects. A subject that is constrained in its operation by Mandatory Access Control policies is still able to operate under the less rigorous constraints of this requirement. Thus, while Mandatory Access Control imposes constraints preventing a subject from passing information to another subject operating at a different sensitivity level, this requirement permits the subject to pass the information to any subject at the same sensitivity level. The policy is bounded by the information system boundary. Once the information is passed outside the control of the information system, additional means may be required to ensure the constraints remain in effect. While the older, more traditional definitions of discretionary access control require identity-based access control, that limitation is not required for this use of discretionary access control.
+
+Satisfies: SRG-OS-000312-GPOS-00122, SRG-OS-000312-GPOS-00123, SRG-OS-000312-GPOS-00124, SRG-OS-000324-GPOS-0012&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109971</ident><ident system="http://cyber.mil/legacy">V-100867</ident><ident system="http://cyber.mil/cci">CCI-002235</ident><ident system="http://cyber.mil/cci">CCI-002165</ident><fixtext fixref="F-21046r305295_fix">Configure the Ubuntu operating system to allow system administrators to pass information to any other Ubuntu operating system administrator or user.
+
+Install "Pam_Apparmor" (if it is not installed) with the following command:
+
+# sudo apt-get install libpam-apparmor
+
+Enable/Activate "Apparmor" (if it is not already active) with the following command:
+
+# sudo systemctl enable apparmor.service
+
+Start "Apparmor" with the following command:
+
+# sudo systemctl start apparmor.service
+
+Note: Pam_Apparmor must have properly configured profiles. All configurations will be based on the actual system setup and organization. See the "Pam_Apparmor" documentation for more information on configuring profiles.</fixtext><fix id="F-21046r305295_fix" /><check system="C-21047r305294_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system is configured to allow system administrators to pass information to any other Ubuntu operating system administrator or user.
+
+Check that "Pam_Apparmor" is installed on the system with the following command:
+
+# dpkg -l | grep -i apparmor
+
+ii libpam-apparmor 2.10.95-0Ubuntu2.6 
+
+If the "Pam_Apparmor" package is not installed, this is a finding.
+
+Check that the "AppArmor" daemon is running with the following command:
+
+# systemctl status apparmor.service | grep -i active
+
+If something other than "Active: active" is returned, this is a finding.
+
+Note: Pam_Apparmor must have properly configured profiles. All configurations will be based on the actual system setup and organization. See the "Pam_Apparmor" documentation for more information on configuring profiles.</check-content></check></Rule></Group><Group id="V-219323"><title>SRG-OS-000368-GPOS-00154</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219323r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010441</version><title>The Ubuntu operating system must be configured to use AppArmor.</title><description>&lt;VulnDiscussion&gt;Control of program execution is a mechanism used to prevent execution of unauthorized programs. Some operating systems may provide a capability that runs counter to the mission or provides users with functionality that exceeds mission requirements. This includes functions and services installed at the operating system level.
+
+Some of the programs, installed by default, may be harmful or may not be necessary to support essential organizational operations (e.g., key missions, functions). Removal of executable programs is not always possible; therefore, establishing a method of preventing program execution is critical to maintaining a secure system baseline.
+
+Methods for complying with this requirement include restricting execution of programs in certain environments, while preventing execution in other environments; or limiting execution of certain program functionality based on organization-defined criteria (e.g., privileges, subnets, sandboxed environments, or roles).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109973</ident><ident system="http://cyber.mil/legacy">V-100869</ident><ident system="http://cyber.mil/cci">CCI-001764</ident><fixtext fixref="F-21047r305298_fix">Install "Apparmor" (if it is not installed) with the following command:
+
+# sudo apt-get install apparmor
+
+# sudo systemctl enable apparmor.service
+
+Start "Apparmor" with the following command:
+
+# sudo systemctl start apparmor.service
+
+Note: Apparmor must have properly configured profiles for applications and home directories. All configurations will be based on the actual system setup and organization and normally are on a per role basis. See the "Apparmor" documentation for more information on configuring profiles.</fixtext><fix id="F-21047r305298_fix" /><check system="C-21048r305297_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the operating system prevents program execution in accordance with local policies.
+
+Check that apparmor is installed and active by running the following command:
+
+# dpkg -l | grep apparmor
+
+If the "apparmor" package is not installed, this is a finding.
+
+#systemctl is-active apparmor.service
+
+active
+
+If "active" is not returned, this is a finding.
+
+#systemctl is-enabled apparmor.service
+
+enabled
+
+If "enabled" is not returned, then this is a finding.</check-content></check></Rule></Group><Group id="V-219324"><title>SRG-OS-000370-GPOS-00155</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219324r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010442</version><title>The Apparmor module must be configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs and limit the ability of non-privileged users to grant other users direct access to the contents of their home directories/folders.</title><description>&lt;VulnDiscussion&gt;Control of program execution is a mechanism used to prevent execution of unauthorized programs. Some operating systems may provide a capability that runs counter to the mission or provides users with functionality that exceeds mission requirements. This includes functions and services installed at the operating system level.
+
+Some of the programs, installed by default, may be harmful or may not be necessary to support essential organizational operations (e.g., key missions, functions). Removal of executable programs is not always possible; therefore, establishing a method of preventing program execution is critical to maintaining a secure system baseline.
+
+Methods for complying with this requirement include restricting execution of programs in certain environments, while preventing execution in other environments; or limiting execution of certain program functionality based on organization-defined criteria (e.g., privileges, subnets, sandboxed environments, or roles).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109975</ident><ident system="http://cyber.mil/legacy">V-100871</ident><ident system="http://cyber.mil/cci">CCI-001774</ident><fixtext fixref="F-21048r305301_fix">Configure the Ubuntu operating system to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs.
+
+Install "Apparmor" (if it is not installed) with the following command:
+
+# sudo apt-get install apparmor
+
+Enable "Apparmor" (if it is not already active) with the following command:
+
+# sudo systemctl enable apparmor.service
+
+Start "Apparmor" with the following command:
+
+# sudo systemctl start apparmor.service
+
+Note: Apparmor must have properly configured profiles for applications and home directories. All configurations will be based on the actual system setup and organization and normally are on a per role basis. See the "Apparmor" documentation for more information on configuring profiles.</fixtext><fix id="F-21048r305301_fix" /><check system="C-21049r305300_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system is configured to employ a deny-all, permit-by-exception policy to allow the execution of authorized software programs and access to user home directories.
+
+Check that "Apparmor" is configured to employ application whitelisting and home directory access control with the following command:
+
+# sudo apparmor_status
+
+apparmor module is loaded.
+17 profiles are loaded.
+17 profiles are in enforce mode.
+ /sbin/dhclient
+ /usr/bin/lxc-start
+ ...
+0 processes are in complain mode.
+0 processes are unconfined but have a profile defined.
+
+If the defined profiles do not match the organization's list of authorized software, this is a finding.</check-content></check></Rule></Group><Group id="V-219325"><title>SRG-OS-000104-GPOS-00051</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219325r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010444</version><title>The Ubuntu operating system must uniquely identify interactive users.</title><description>&lt;VulnDiscussion&gt;To assure accountability and prevent unauthenticated access, organizational users must be identified and authenticated to prevent potential misuse and compromise of the system.
+
+Organizational users include organizational employees or individuals the organization deems to have equivalent status of employees (e.g., contractors). Organizational users (and processes acting on behalf of users) must be uniquely identified and authenticated to all accesses, except for the following: 
+
+1) Accesses explicitly identified and documented by the organization. Organizations document specific user actions that can be performed on the information system without identification or authentication; and
+
+2) Accesses that occur through authorized use of group authenticators without individual authentication. Organizations may require unique identification of individuals in group accounts (e.g., shared privilege accounts) or for detailed accountability of individual activity.
+
+Satisfies: SRG-OS-000104-GPOS-00051, SRG-OS-000121-GPOS-00062&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109977</ident><ident system="http://cyber.mil/legacy">V-100873</ident><ident system="http://cyber.mil/cci">CCI-000764</ident><ident system="http://cyber.mil/cci">CCI-000804</ident><fixtext fixref="F-21049r305304_fix">Edit the file "/etc/passwd" and provide each interactive user account that has a duplicate User ID (UID) with a unique UID.</fixtext><fix id="F-21049r305304_fix" /><check system="C-21050r305303_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that the Ubuntu operating system contains no duplicate User IDs (UIDs) for interactive users.
+
+Check that the Ubuntu operating system contains no duplicate UIDs for interactive users with the following command:
+
+# awk -F ":" 'list[$3]++{print $1, $3}' /etc/passwd
+
+If output is produced, and the accounts listed are interactive user accounts, this is a finding.</check-content></check></Rule></Group><Group id="V-219326"><title>SRG-OS-000118-GPOS-00060</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219326r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010445</version><title>The Ubuntu operating system must disable account identifiers (individuals, groups, roles, and devices) after 35 days of inactivity.</title><description>&lt;VulnDiscussion&gt;Inactive identifiers pose a risk to systems and applications because attackers may exploit an inactive identifier and potentially obtain undetected access to the system. Owners of inactive accounts will not notice if unauthorized access to their user account has been obtained.
+
+Ubuntu operating systems need to track periods of inactivity and disable application identifiers after 35 days of inactivity.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109979</ident><ident system="http://cyber.mil/legacy">V-100875</ident><ident system="http://cyber.mil/cci">CCI-000795</ident><fixtext fixref="F-21050r305307_fix">Configure the Ubuntu operating system to disable account identifiers after 35 days of inactivity after the password expiration. 
+
+Run the following command to change the configuration for adduser:
+
+# sudo useradd -D -f 35
+
+Note: DoD recommendation is 35 days, but a lower value is acceptable. The value "0" will disable the account immediately after the password expires.</fixtext><fix id="F-21050r305307_fix" /><check system="C-21051r305306_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the account identifiers (individuals, groups, roles, and devices) are disabled after 35 days of inactivity with the following command:
+
+Check the account inactivity value by performing the following command:
+
+# sudo grep INACTIVE /etc/default/useradd
+
+INACTIVE=35
+
+If "INACTIVE" is not set to a value 0&lt;[VALUE]&lt;=35, or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219327"><title>SRG-OS-000123-GPOS-00064</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219327r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010447</version><title>The Ubuntu operating system must automatically remove or disable emergency accounts after 72 hours.</title><description>&lt;VulnDiscussion&gt;Emergency accounts are different from infrequently used accounts (i.e., local logon accounts used by the organization's system administrators when network or normal logon/access is not available). Infrequently used accounts are not subject to automatic termination dates. Emergency accounts are accounts created in response to crisis situations, usually for use by maintenance personnel. The automatic expiration or disabling time period may be extended as needed until the crisis is resolved; however, it must not be extended indefinitely. A permanent account should be established for privileged users who need long-term maintenance accounts.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109981</ident><ident system="http://cyber.mil/legacy">V-100877</ident><ident system="http://cyber.mil/cci">CCI-001682</ident><fixtext fixref="F-21051r305310_fix">If an emergency account must be created, configure the system to terminate the account after a 72 hour time period with the following command to set an expiration date on it. Substitute "account_name" with the account to be created.
+
+# sudo chage -E $(date -d "+3 days" +%F) account_name</fixtext><fix id="F-21051r305310_fix" /><check system="C-21052r305309_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system expires emergency accounts within 72 hours or less.
+For every emergency account, run the following command to obtain its account expiration information.
+
+# sudo chage -l account_name | grep expires
+
+Password expires : Aug 07, 2019
+Account expires : Aug 07, 2019
+
+Verify each of these accounts has an expiration date set within 72 hours of accounts' creation.
+If any of these accounts do not expire within 72 hours of that account's creation, this is a finding.</check-content></check></Rule></Group><Group id="V-219328"><title>SRG-OS-000480-GPOS-00228</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219328r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010448</version><title>The Ubuntu operating system default filesystem permissions must be defined in such a way that all authenticated users can only read and modify their own files.</title><description>&lt;VulnDiscussion&gt;Setting the most restrictive default permissions ensures that when new accounts are created they do not have unnecessary access.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109983</ident><ident system="http://cyber.mil/legacy">V-100879</ident><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-21052r305313_fix">Configure the system to define the default permissions for all authenticated users in such a way that the user can only read and modify their own files.
+
+Edit the "UMASK" parameter in the "/etc/login.defs" file to match the example below:
+
+UMASK 077</fixtext><fix id="F-21052r305313_fix" /><check system="C-21053r305312_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system defines default permissions for all authenticated users in such a way that the user can only read and modify their own files.
+
+Check that the Ubuntu operating system defines default permissions for all authenticated users with the following command: 
+
+# grep -i "umask" /etc/login.defs
+
+UMASK 077
+
+If the "UMASK" variable is set to "000", this is a finding with the severity raised to a CAT I.
+
+If the value of "UMASK" is not set to "077", "UMASK" is commented out or "UMASK" is missing completely, this is a finding.</check-content></check></Rule></Group><Group id="V-219329"><title>SRG-OS-000002-GPOS-00002</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219329r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010449</version><title>The Ubuntu operating system must provision temporary user accounts with an expiration time of 72 hours or less.</title><description>&lt;VulnDiscussion&gt;If temporary user accounts remain active when no longer needed or for an excessive period, these accounts may be used to gain unauthorized access. To mitigate this risk, automated termination of all temporary accounts must be set upon account creation.
+
+Temporary accounts are established as part of normal account activation procedures when there is a need for short-term accounts without the demand for immediacy in account activation.
+
+If temporary accounts are used, the Ubuntu operating system must be configured to automatically terminate these types of accounts after a DoD-defined time period of 72 hours.
+
+To address access requirements, the Ubuntu operating system may be integrated with enterprise-level authentication/access mechanisms that meet or exceed access control policy requirements.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109985</ident><ident system="http://cyber.mil/legacy">V-100881</ident><ident system="http://cyber.mil/cci">CCI-000016</ident><fixtext fixref="F-21053r305316_fix">If a temporary account must be created configure the system to terminate the account after a 72 hour time period with the following command to set an expiration date on it. Substitute "system_account_name" with the account to be created.
+
+# sudo chage -E $(date -d "+3 days" +%F) system_account_name</fixtext><fix id="F-21053r305316_fix" /><check system="C-21054r305315_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system expires temporary user accounts within 72 hours or less.
+
+For every existing temporary account, run the following command to obtain its account expiration information.
+
+# sudo chage -l system_account_name | grep expires
+
+Password expires : Aug 07, 2019
+Account expires : Aug 07, 2019
+
+Verify each of these accounts has an expiration date set within 72 hours of accounts' creation.
+If any temporary account does not expire within 72 hours of that account's creation, this is a finding.</check-content></check></Rule></Group><Group id="V-219330"><title>SRG-OS-000142-GPOS-00071</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219330r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010500</version><title>The Ubuntu operating system must be configured to use TCP syncookies.</title><description>&lt;VulnDiscussion&gt;DoS is a condition when a resource is not available for legitimate users. When this occurs, the organization either cannot accomplish its mission or must operate at degraded capacity. 
+
+Managing excess capacity ensures that sufficient capacity is available to counter flooding attacks. Employing increased capacity and service redundancy may reduce the susceptibility to some DoS attacks. Managing excess capacity may include, for example, establishing selected usage priorities, quotas, or partitioning.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109987</ident><ident system="http://cyber.mil/legacy">V-100883</ident><ident system="http://cyber.mil/cci">CCI-001095</ident><fixtext fixref="F-21054r305319_fix">Configure the Ubuntu operating system to use TCP syncookies, by running the following command:
+
+# sudo sysctl -w net.ipv4.tcp_syncookies=1
+
+If "1" is not the system's default value then add or update the following line in "/etc/sysctl.conf":
+
+net.ipv4.tcp_syncookies = 1</fixtext><fix id="F-21054r305319_fix" /><check system="C-21055r305318_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is configured to use TCP syncookies.
+
+Check the value of TCP syncookies with the following command:
+
+# sysctl net.ipv4.tcp_syncookies
+net.ipv4.tcp_syncookies = 1
+
+If the value is not "1", this is a finding.
+
+Check the saved value of TCP syncookies with the following command:
+
+# sudo grep -i net.ipv4.tcp_syncookies /etc/sysctl.conf /etc/sysctl.d/* | grep -v '#'
+
+If no output is returned, this is a finding.</check-content></check></Rule></Group><Group id="V-219331"><title>SRG-OS-000355-GPOS-00143</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219331r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010501</version><title>The Ubuntu operating system must, for networked systems, compare internal information system clocks at least every 24 hours with a server which is synchronized to one of the redundant United States Naval Observatory (USNO) time servers, or a time server designated for the appropriate DoD network (NIPRNet/SIPRNet), and/or the Global Positioning System (GPS).</title><description>&lt;VulnDiscussion&gt;Inaccurate time stamps make it more difficult to correlate events and can lead to an inaccurate analysis. Determining the correct time a particular event occurred on a system is critical when conducting forensic analysis and investigating system events. Sources outside the configured acceptable allowance (drift) may be inaccurate.
+
+Synchronizing internal information system clocks provides uniformity of time stamps for information systems with multiple system clocks and systems connected over a network.
+
+Organizations should consider endpoints that may not have regular access to the authoritative time server (e.g., mobile, teleworking, and tactical endpoints).&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">V-100885</ident><ident system="http://cyber.mil/legacy">SV-109989</ident><ident system="http://cyber.mil/cci">CCI-001891</ident><fixtext fixref="F-21055r608760_fix">If the system is not networked this requirement is Not Applicable.
+
+To configure the system clock to compare the system clock at least every 24 hours to the authoritative time source, edit the "/etc/chrony/chrony.conf" file. Add or correct the following lines, by replacing "[source]" in the following line with an authoritative DoD time source.
+
+server [source] iburst maxpoll = 17
+
+If the "chrony" service was running and the value of "maxpoll" or "server" was updated then the service must be restarted using the following command:
+
+# sudo systemctl restart chrony.service</fixtext><fix id="F-21055r608760_fix" /><check system="C-21056r305321_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>If the system is not networked this requirement is Not Applicable.
+
+The system clock must be configured to compare the system clock at least every 24 hours to the authoritative time source.
+
+Check the value of "maxpoll" in the "/etc/chrony/chrony.conf" file with the following command:
+
+# sudo grep maxpoll /etc/chrony/chrony.conf
+server tick.usno.navy.mil iburst maxpoll 17
+
+If "maxpoll" is not set to "17" or does not exist, this is a finding.
+
+Verify that the "chrony.conf" file is configured to an authoritative DoD time source by running the following command:
+
+# grep -i server /etc/chrony/chrony.conf
+server tick.usno.navy.mil iburst maxpoll 17
+server tock.usno.navy.mil iburst maxpoll 17
+server ntp2.usno.navy.mil iburst maxpoll 17
+
+If the parameter "server" is not set, is not set to an authoritative DoD time source, or is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219332"><title>SRG-OS-000356-GPOS-00144</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219332r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010502</version><title>The Ubuntu operating system must synchronize internal information system clocks to the authoritative time source when the time difference is greater than one second.</title><description>&lt;VulnDiscussion&gt;Inaccurate time stamps make it more difficult to correlate events and can lead to an inaccurate analysis. Determining the correct time a particular event occurred on a system is critical when conducting forensic analysis and investigating system events.
+
+Synchronizing internal information system clocks provides uniformity of time stamps for information systems with multiple system clocks and systems connected over a network. Organizations should consider setting time periods for different types of systems (e.g., financial, legal, or mission-critical systems).
+
+Organizations should also consider endpoints that may not have regular access to the authoritative time server (e.g., mobile, teleworking, and tactical endpoints). This requirement is related to the comparison done every 24 hours in SRG-OS-000355 because a comparison must be done in order to determine the time difference.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109991</ident><ident system="http://cyber.mil/legacy">V-100887</ident><ident system="http://cyber.mil/cci">CCI-002046</ident><fixtext fixref="F-21056r305325_fix">Configure chrony to synchronize the internal system clocks to the authoritative source when the time difference is greater than one second by doing the following,
+
+Edit the /etc/chrony/chrony.conf file and add:
+
+makestep 1 -1
+
+Restart the chrony service,
+
+# sudo systemctl restart chrony.service</fixtext><fix id="F-21056r305325_fix" /><check system="C-21057r305324_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the operating system synchronizes internal system clocks to the authoritative time source when the time difference is greater than one second.
+
+Check the value of "makestep" by running the following command:
+
+# sudo grep makestep /etc/chrony/chrony.conf
+
+makestep 1 -1
+
+If the makestep option is commented out or is not set to "1 -1", this is a finding.</check-content></check></Rule></Group><Group id="V-219333"><title>SRG-OS-000359-GPOS-00146</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219333r610963_rule" severity="low" weight="10.0"><version>UBTU-18-010503</version><title>The Ubuntu operating system must record time stamps for audit records that can be mapped to Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT).</title><description>&lt;VulnDiscussion&gt;If time stamps are not consistently applied and there is no common time reference, it is difficult to perform forensic analysis.
+
+Time stamps generated by the operating system include date and time. Time is commonly expressed in Coordinated Universal Time (UTC), a modern continuation of Greenwich Mean Time (GMT), or local time with an offset from UTC.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109993</ident><ident system="http://cyber.mil/legacy">V-100889</ident><ident system="http://cyber.mil/cci">CCI-001890</ident><fixtext fixref="F-21057r305328_fix">To configure the system time zone to use Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT), run the following command replacing [ZONE] with UTC or GMT.
+
+# sudo timedatectl set-timezone [ZONE]</fixtext><fix id="F-21057r305328_fix" /><check system="C-21058r305327_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>The time zone must be configured to use Coordinated Universal Time (UTC) or Greenwich Mean Time (GMT). To verify run the following command. 
+
+# sudo timedatectl status | grep -i "time zone"
+Timezone: UTC (UTC, +0000)
+
+If "Timezone" is not set to UTC or GMT, this is a finding.</check-content></check></Rule></Group><Group id="V-219334"><title>SRG-OS-000096-GPOS-00050</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219334r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010504</version><title>The Ubuntu operating system must be configured to prohibit or restrict the use of functions, ports, protocols, and/or services, as defined in the PPSM CAL and vulnerability assessments.</title><description>&lt;VulnDiscussion&gt;In order to prevent unauthorized connection of devices, unauthorized transfer of information, or unauthorized tunneling (i.e., embedding of data types within data types), organizations must disable or restrict unused or unnecessary physical and logical ports/protocols on information systems.
+
+The Ubuntu operating system is capable of providing a wide variety of functions and services. Some of the functions and services provided by default may not be necessary to support essential organizational operations. Additionally, it is sometimes convenient to provide multiple services from a single component (e.g., VPN and IPS); however, doing so increases risk over limiting the services provided by any one component.
+
+To support the requirements and principles of least functionality, the Ubuntu operating system must support the organizational requirements, providing only essential capabilities and limiting the use of ports, protocols, and/or services to only those required, authorized, and approved to conduct official business or to address authorized quality of life issues.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109995</ident><ident system="http://cyber.mil/legacy">V-100891</ident><ident system="http://cyber.mil/cci">CCI-000382</ident><fixtext fixref="F-21058r305331_fix">Add all ports, protocols or services allowed by the PPSM CLSA by using the following command:
+
+# ufw allow &lt;direction&gt; &lt;port/protocol/service&gt;
+
+where the direction is 'in' or 'out' and the port is the one corresponding to the protocol or service allowed.
+
+To deny access to port, protocols or services, use:
+
+# ufw deny &lt;direction&gt; &lt;port/protocol/service&gt;</fixtext><fix id="F-21058r305331_fix" /><check system="C-21059r305330_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system is configured to prohibit or restrict the use of functions, ports, protocols, and/or services as defined in the Ports, Protocols, and Services Management (PPSM) Category Assignments List (CAL) and vulnerability assessments.
+
+Check the firewall configuration for any unnecessary or prohibited functions, ports, protocols, and/or services by running the following command:
+
+# sudo ufw show raw
+
+Chain OUTPUT (policy ACCEPT)
+target prot opt sources destination
+Chain INPUT (policy ACCEPT 1 packets, 40 bytes)
+ pkts bytes target prot opt in out source destination
+
+Chain FORWARD (policy ACCEPT 0 packets, 0 bytes)
+ pkts bytes target prot opt in out source destination
+
+Chain OUTPUT (policy ACCEPT 0 packets, 0 bytes)
+ pkts bytes target prot opt in out source destination
+
+Ask the system administrator for the site or program PPSM CLSA. Verify the services allowed by the firewall match the PPSM Component Local Services Assessment (CLSA). 
+
+If there are any additional ports, protocols, or services that are not included in the PPSM CLSA, this is a finding.
+
+If there are any ports, protocols, or services that are prohibited by the PPSM CAL, this is a finding.</check-content></check></Rule></Group><Group id="V-219335"><title>SRG-OS-000184-GPOS-00078</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219335r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010505</version><title>Kernel core dumps must be disabled unless needed.</title><description>&lt;VulnDiscussion&gt;Kernel core dumps may contain the full contents of system memory at the time of the crash. Kernel core dumps may consume a considerable amount of disk space and may result in denial of service by exhausting the available space on the target file system partition.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109997</ident><ident system="http://cyber.mil/legacy">V-100893</ident><ident system="http://cyber.mil/cci">CCI-001190</ident><fixtext fixref="F-21059r305334_fix">If kernel core dumps are not required, disable the "kdump" service with the following command:
+
+# systemctl disable kdump.service
+
+If kernel core dumps are required, document the need with the Information System Security Officer (ISSO).</fixtext><fix id="F-21059r305334_fix" /><check system="C-21060r305333_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that kernel core dumps are disabled unless needed.
+
+Check if "kdump" service is active with the following command:
+
+# systemctl is-active kdump.service
+inactive
+
+If the "kdump" service is active, ask the System Administrator if the use of the service is required and documented with the Information System Security Officer (ISSO).
+
+If the service is active and is not documented, this is a finding.</check-content></check></Rule></Group><Group id="V-219336"><title>SRG-OS-000278-GPOS-00108</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219336r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010506</version><title>The Ubuntu operating system must use cryptographic mechanisms to protect the integrity of audit tools.</title><description>&lt;VulnDiscussion&gt;Protecting the integrity of the tools used for auditing purposes is a critical step toward ensuring the integrity of audit information. Audit information includes all information (e.g., audit records, audit settings, and audit reports) needed to successfully audit information system activity.
+
+Audit tools include, but are not limited to, vendor-provided and open source audit tools needed to successfully view and manipulate audit information system activity and records. Audit tools include custom queries and report generators.
+
+It is not uncommon for attackers to replace the audit tools or inject code into the existing tools with the purpose of providing the capability to hide or erase system activity from the audit logs.
+
+To address this risk, audit tools must be cryptographically signed in order to provide the capability to identify when the audit tools have been modified, manipulated, or replaced. An example is a checksum hash of the file or files.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-109999</ident><ident system="http://cyber.mil/legacy">V-100895</ident><ident system="http://cyber.mil/cci">CCI-001496</ident><fixtext fixref="F-21060r305337_fix">Add or update the following selection lines to "/etc/aide/aide.conf", in order to protect the integrity of the audit tools.
+
+# Audit Tools
+/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/audispd p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512</fixtext><fix id="F-21060r305337_fix" /><check system="C-21061r305336_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that Advanced Intrusion Detection Environment (AIDE) is properly configured to use cryptographic mechanisms to protect the integrity of audit tools.
+
+Check the selection lines that aide is configured to add/check with the following command:
+
+# egrep '(\/sbin\/(audit|au))' /etc/aide/aide.conf
+
+/sbin/auditctl p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/auditd p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/ausearch p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/aureport p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/autrace p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/audispd p+i+n+u+g+s+b+acl+xattrs+sha512
+/sbin/augenrules p+i+n+u+g+s+b+acl+xattrs+sha512
+
+If any of the seven audit tools does not have an appropriate selection line, this is a finding.</check-content></check></Rule></Group><Group id="V-219337"><title>SRG-OS-000297-GPOS-00115</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219337r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010507</version><title>The Ubuntu operating system must enable and run the uncomplicated firewall(ufw).</title><description>&lt;VulnDiscussion&gt;Remote access services, such as those providing remote access to network devices and information systems, which lack automated control capabilities, increase risk and make remote user access management difficult at best.
+
+Remote access is access to DoD nonpublic information systems by an authorized user (or an information system) communicating through an external, non-organization-controlled network. Remote access methods include, for example, dial-up, broadband, and wireless.
+
+Ubuntu operating system functionality (e.g., RDP) must be capable of taking enforcement action if the audit reveals unauthorized activity. Automated control of remote access sessions allows organizations to ensure ongoing compliance with remote access policies by enforcing connection rules of remote access applications on a variety of information system components (e.g., servers, workstations, notebook computers, smartphones, and tablets).
+
+Satisfies: SRG-OS-000480-GPOS-00232&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110001</ident><ident system="http://cyber.mil/legacy">V-100897</ident><ident system="http://cyber.mil/cci">CCI-002314</ident><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-21061r569467_fix">Enable the Uncomplicated Firewall by using the following command:
+
+# sudo systemctl enable ufw.service 
+
+If the Uncomplicated Firewall is not currently running on the system, start it with the following command:
+
+# sudo systemctl start ufw.service</fixtext><fix id="F-21061r569467_fix" /><check system="C-21062r569466_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Uncomplicated Firewall is enabled on the system by running the following command:
+
+# systemctl is-enabled ufw
+
+If the above command returns the status as "disabled", this is a finding.
+
+Verify the Uncomplicated Firewall is active on the system by running the following command:
+
+# sudo systemctl is-active ufw
+
+If the above command returns 'inactive' or any kind of error, this is a finding.
+
+If the Uncomplicated Firewall is not installed ask the System Administrator if another application firewall is installed. 
+
+If no application firewall is installed this is a finding.</check-content></check></Rule></Group><Group id="V-219338"><title>SRG-OS-000363-GPOS-00150</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219338r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010508</version><title>The Ubuntu operating system must notify designated personnel if baseline configurations are changed in an unauthorized manner. The file integrity tool must notify the system administrator when changes to the baseline configuration or anomalies in the operation of any security functions are discovered.</title><description>&lt;VulnDiscussion&gt;Unauthorized changes to the baseline configuration could make the system vulnerable to various attacks or allow unauthorized access to the Ubuntu operating system. Changes to Ubuntu operating system configurations can have unintended side effects, some of which may be relevant to security.
+
+Detecting such changes and providing an automated response can help avoid unintended, negative consequences that could ultimately affect the security state of the Ubuntu operating system. The Ubuntu operating system's IMO/ISSO and SAs must be notified via email and/or monitoring system trap when there is an unauthorized modification of a configuration item.
+
+Satisfies: SRG-OS-000363-GPOS-00150, SRG-OS-000447-GPOS-00201&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110003</ident><ident system="http://cyber.mil/legacy">V-100899</ident><ident system="http://cyber.mil/cci">CCI-001744</ident><ident system="http://cyber.mil/cci">CCI-002702</ident><fixtext fixref="F-21062r305343_fix">Configure the Ubuntu operating system to notify designated personnel if baseline configurations are changed in an unauthorized manner.
+
+Modify the "SILENTREPORTS" parameter in the "/etc/default/aide" file with a value of "no" if it does not already exist.</fixtext><fix id="F-21062r305343_fix" /><check system="C-21063r305342_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that Advanced Intrusion Detection Environment (AIDE) notifies the system administrator when anomalies in the operation of any security functions are discovered.
+
+Check that AIDE notifies the system administrator when anomalies in the operation of any security functions are discovered with the following command:
+
+#sudo grep SILENTREPORTS /etc/default/aide
+
+SILENTREPORTS=no
+
+If SILENTREPORTS is uncommented and set to yes, this is a finding.</check-content></check></Rule></Group><Group id="V-219339"><title>SRG-OS-000378-GPOS-00163</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219339r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010509</version><title>The Ubuntu operating system must disable automatic mounting of Universal Serial Bus (USB) mass storage driver.</title><description>&lt;VulnDiscussion&gt;Without authenticating devices, unidentified or unknown devices may be introduced, thereby facilitating malicious activity.
+
+Peripherals include, but are not limited to, such devices as flash drives, external storage, and printers.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110023</ident><ident system="http://cyber.mil/legacy">V-100919</ident><ident system="http://cyber.mil/cci">CCI-001958</ident><fixtext fixref="F-21063r305346_fix">Configure the Ubuntu operating system to disable using the USB storage kernel module. 
+
+Create a file under "/etc/modprobe.d" to contain the following:
+
+# sudo su -c "echo install usb-storage /bin/true &gt;&gt; /etc/modprobe.d/DISASTIG.conf"
+
+Configure the operating system to disable the ability to use USB mass storage devices.
+
+# sudo su -c "echo blacklist usb-storage &gt;&gt; /etc/modprobe.d/DISASTIG.conf"</fixtext><fix id="F-21063r305346_fix" /><check system="C-21064r305345_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that Ubuntu operating system disables ability to load the USB storage kernel module.
+
+# grep usb-storage /etc/modprobe.d/* | grep "/bin/true" 
+
+install usb-storage /bin/true
+
+If the command does not return any output, or the line is commented out, this is a finding.
+
+Verify the operating system disables the ability to use USB mass storage device.
+
+# grep usb-storage /etc/modprobe.d/* | grep -i "blacklist"
+
+blacklist usb-storage
+
+If the command does not return any output, or the line is commented out, this is a finding.</check-content></check></Rule></Group><Group id="V-219340"><title>SRG-OS-000420-GPOS-00186</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219340r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010512</version><title>The Ubuntu operating system must configure the uncomplicated firewall to rate-limit impacted network interfaces.</title><description>&lt;VulnDiscussion&gt;DoS is a condition when a resource is not available for legitimate users. When this occurs, the organization either cannot accomplish its mission or must operate at degraded capacity.
+
+This requirement addresses the configuration of the Ubuntu operating system to mitigate the impact of DoS attacks that have occurred or are ongoing on system availability. For each system, known and potential DoS attacks must be identified and solutions for each type implemented. A variety of technologies exist to limit or, in some cases, eliminate the effects of DoS attacks (e.g., limiting processes or establishing memory partitions). Employing increased capacity and bandwidth, combined with service redundancy, may reduce the susceptibility to some DoS attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110005</ident><ident system="http://cyber.mil/legacy">V-100901</ident><ident system="http://cyber.mil/cci">CCI-002385</ident><fixtext fixref="F-21064r305349_fix">Configure the application firewall to protect against or limit the effects of Denial of Service (DoS) attacks by ensuring the Ubuntu operating system is implementing rate-limiting measures on impacted network interfaces.
+
+Run the following command replacing "[service]" with the service that needs to be rate limited.
+
+# sudo ufw limit [service]
+
+Or rate-limiting can be done on an interface. An example of adding a rate-limit on the eth0 interface:
+
+# sudo ufw limit in on eth0</fixtext><fix id="F-21064r305349_fix" /><check system="C-21065r305348_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify an application firewall is configured to rate limit any connection to the system.
+
+Check that the Uncomplicated Firewall is configured to rate limit any connection to the system with the following command:
+
+# sudo ufw show raw
+
+Chain ufw-user-input (1 references)
+pkts bytes target prot opt in out source destination
+0 0 ufw-user-limit all -- eth0 * 0.0.0.0/0 0.0.0.0/0
+ctstate NEW recent: UPDATE seconds: 30 hit_count: 6 name: DEFAULT side:
+source mask: 255.255.255.255
+
+0 0 ufw-user-limit-accept all -- eth0 * 0.0.0.0/0 0.0.0.0/0
+
+If any service is not rate limited by the Uncomplicated Firewall, this is a finding.</check-content></check></Rule></Group><Group id="V-219341"><title>SRG-OS-000433-GPOS-00192</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219341r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010513</version><title>The Ubuntu operating system must implement non-executable data to protect its memory from unauthorized code execution.</title><description>&lt;VulnDiscussion&gt;Some adversaries launch attacks with the intent of executing code in non-executable regions of memory or in memory locations that are prohibited. Security safeguards employed to protect memory include, for example, data execution prevention and address space layout randomization. Data execution prevention safeguards can either be hardware-enforced or software-enforced with hardware providing the greater strength of mechanism.
+
+Examples of attacks are buffer overflow attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110007</ident><ident system="http://cyber.mil/legacy">V-100903</ident><ident system="http://cyber.mil/cci">CCI-002824</ident><fixtext fixref="F-21065r305352_fix">Configure the Ubuntu operating system to enable NX.
+
+If "nx" is not showing up in /proc/cpuinfo and the system's BIOS setup configuration permits toggling the No Execution bit, then set it to "enable".</fixtext><fix id="F-21065r305352_fix" /><check system="C-21066r305351_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the NX (no-execution) bit flag is set on the system.
+
+Check that the no-execution bit flag is set with the following commands:
+
+# dmesg | grep -i "execute disable"
+[ 0.000000] NX (Execute Disable) protection: active
+
+If "dmesg" does not show "NX (Execute Disable) protection: active", check the cpuinfo settings with the following command: 
+
+# grep flags /proc/cpuinfo | grep -w nx | sort -u
+flags : fpu vme de pse tsc ms nx rdtscp lm constant_tsc
+
+If "flags" does not contain the "nx" flag, this is a finding.</check-content></check></Rule></Group><Group id="V-219342"><title>SRG-OS-000433-GPOS-00193</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219342r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010514</version><title>The Ubuntu operating system must implement address space layout randomization to protect its memory from unauthorized code execution.</title><description>&lt;VulnDiscussion&gt;Some adversaries launch attacks with the intent of executing code in non-executable regions of memory or in memory locations that are prohibited. Security safeguards employed to protect memory include, for example, data execution prevention and address space layout randomization. Data execution prevention safeguards can either be hardware-enforced or software-enforced with hardware providing the greater strength of mechanism.
+
+Examples of attacks are buffer overflow attacks.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110009</ident><ident system="http://cyber.mil/legacy">V-100905</ident><ident system="http://cyber.mil/cci">CCI-002824</ident><fixtext fixref="F-21066r569470_fix">Set the "kernel.randomize_va_space" entry found in the "/etc/sysctl.conf" file to a value of "2".
+
+After the line has been modified the kernel settings from all system configuration files must be reloaded; before any of the changes will take effect. 
+
+Run the following command to reload all of the kernel system configuration files:
+
+# sudo sysctl --system
+</fixtext><fix id="F-21066r569470_fix" /><check system="C-21067r569469_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the Ubuntu operating system implements address space layout randomization (ASLR).
+
+Check that ASLR is configured on the system with the following command:
+
+# sudo sysctl kernel.randomize_va_space
+
+kernel.randomize_va_space = 2
+
+Verify the kernel parameter "randomize_va_space" is set to 2 with the following command:
+
+# cat /proc/sys/kernel/randomize_va_space
+
+2
+
+If "kernel.randomize_va_space" is not set to 2, this is a finding.
+
+Check the saved value of the kernel.randomize_va_space variable is not different from 2.
+
+# sudo egrep -R "^kernel.randomize_va_space=[^2]" /etc/sysctl.conf /etc/sysctl.d
+
+If this returns a result, this is a finding.</check-content></check></Rule></Group><Group id="V-219343"><title>SRG-OS-000445-GPOS-00199</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219343r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010515</version><title>The Ubuntu operating system must use a file integrity tool to verify correct operation of all security functions.</title><description>&lt;VulnDiscussion&gt;Without verification of the security functions, security functions may not operate correctly and the failure may go unnoticed. Security function is defined as the hardware, software, and/or firmware of the information system responsible for enforcing the system security policy and supporting the isolation of code and data on which the protection is based. Security functionality includes, but is not limited to, establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters.
+
+This requirement applies to the Ubuntu operating system performing security function verification/testing and/or systems and environments that require this functionality.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110011</ident><ident system="http://cyber.mil/legacy">V-100907</ident><ident system="http://cyber.mil/cci">CCI-002696</ident><fixtext fixref="F-21067r305358_fix">Install the AIDE package by running the following command:
+
+# sudo apt-get install aide</fixtext><fix id="F-21067r305358_fix" /><check system="C-21068r305357_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that Advanced Intrusion Detection Environment (AIDE) is installed and verifies the correct operation of all security functions.
+
+Check that the AIDE package is installed with the following command:
+
+# sudo dpkg -l | grep aide
+
+aide/xenial,now 0.16~a2.git20130520-3 amd64 [installed]
+
+If AIDE is not installed, ask the System Administrator how file integrity checks are performed on the system. 
+
+If there is no application installed to perform integrity checks, this is a finding.</check-content></check></Rule></Group><Group id="V-219344"><title>SRG-OS-000446-GPOS-00200</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219344r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010516</version><title>The Ubuntu operating system must be configured so that a file integrity tool verifies the correct operation of security functions every 30 days.</title><description>&lt;VulnDiscussion&gt;Without verification of the security functions, security functions may not operate correctly and the failure may go unnoticed. Security function is defined as the hardware, software, and/or firmware of the information system responsible for enforcing the system security policy and supporting the isolation of code and data on which the protection is based. Security functionality includes, but is not limited to, establishing system accounts, configuring access authorizations (i.e., permissions, privileges), setting events to be audited, and setting intrusion detection parameters.
+
+Notifications provided by information systems include, for example, electronic alerts to system administrators, messages to local computer consoles, and/or hardware indications, such as lights.
+
+This requirement applies to the Ubuntu operating system performing security function verification/testing and/or systems and environments that require this functionality.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110013</ident><ident system="http://cyber.mil/legacy">V-100909</ident><ident system="http://cyber.mil/cci">CCI-002699</ident><fixtext fixref="F-21068r305361_fix">The cron file for AIDE is fairly complex as it creates the report. This file is installed with the aide-common package and the default can be restored by copying it from another location:
+
+# sudo cp /usr/share/aide/config/cron.daily/aide /etc/cron.daily/aide</fixtext><fix id="F-21068r305361_fix" /><check system="C-21069r305360_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that Advanced Intrusion Detection Environment (AIDE) performs a verification of the operation of security functions every 30 days.
+
+Note: A file integrity tool other than AIDE may be used, but the tool must be executed at least once per week.
+
+Check that AIDE is being executed every 30 days or less with the following command:
+
+# ls -al /etc/cron.daily/aide
+
+-rwxr-xr-x 1 root root 26049 Oct 24 2014 /etc/cron.daily/aide
+
+If the "/etc/cron.daily/aide" file does not exist or a cron job is not configured to run at least every 30 days, this is a finding.</check-content></check></Rule></Group><Group id="V-219346"><title>SRG-OS-000481-GPOS-000481</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-219346r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010521</version><title>The Ubuntu operating system must disable all wireless network adapters.</title><description>&lt;VulnDiscussion&gt;Without protection of communications with wireless peripherals, confidentiality and integrity may be compromised because unprotected communications can be intercepted and either read, altered, or used to compromise the operating system.
+
+This requirement applies to wireless peripheral technologies (e.g., wireless mice, keyboards, displays, etc.) used with an operating system. Wireless peripherals (e.g., Wi-Fi/Bluetooth/IR Keyboards, Mice, and Pointing Devices and Near Field Communications [NFC]) present a unique challenge by creating an open, unsecured port on a computer. Wireless peripherals must meet DoD requirements for wireless data transmission and be approved for use by the AO. Even though some wireless peripherals, such as mice and pointing devices, do not ordinarily carry information that need to be protected, modification of communications with these wireless peripherals may be used to compromise the operating system. Communication paths outside the physical protection of a controlled boundary are exposed to the possibility of interception and modification.
+
+Protecting the confidentiality and integrity of communications with wireless peripherals can be accomplished by physical means (e.g., employing physical barriers to wireless radio frequencies) or by logical means (e.g., employing cryptographic techniques). If physical means of protection are employed, then logical means (cryptography) do not have to be employed, and vice versa. If the wireless peripheral is only passing telemetry data, encryption of the data may not be required.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/legacy">SV-110017</ident><ident system="http://cyber.mil/legacy">V-100913</ident><ident system="http://cyber.mil/cci">CCI-002418</ident><fixtext fixref="F-21070r305367_fix">Configure the system to disable all wireless network interfaces with the following command:
+
+# sudo ifdown [ADAPTER_NAME]</fixtext><fix id="F-21070r305367_fix" /><check system="C-21071r305366_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that there are no wireless interfaces configured on the system.
+
+Check that the system does not have active wireless interfaces with the following command:
+
+Note: This requirement is Not Applicable for systems that do not have physical wireless network radios.
+
+# ifconfig -a | more
+
+eth0 Link encap:Ethernet HWaddr ff:ff:ff:ff:ff:ff 
+ inet addr:192.168.2.100 Bcast:192.168.2.255 Mask:255.255.255.0
+ ...
+
+eth1 IEEE 802.11b ESSID:"tacnet"
+ Mode:Managed Frequency:2.412 GHz Access Point: 00:40:E7:22:45:CD
+ ...
+
+lo Link encap:Local Loopback 
+ inet addr:127.0.0.1 Mask:255.0.0.0
+ inet6 addr: ::1/128 Scope:Host
+ ...
+
+If a wireless interface is configured and has not been documented and approved by the Information System Security Officer (ISSO), this is a finding.</check-content></check></Rule></Group><Group id="V-233779"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-233779r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010418</version><title>The Ubuntu operating system must be configured so that remote X connections are disabled, unless to fulfill documented and validated mission requirements.</title><description>&lt;VulnDiscussion&gt;The security risk of using X11 forwarding is that the client's X11 display server may be exposed to attack when the SSH client requests forwarding. A system administrator may have a stance in which they want to protect clients that may expose themselves to attack by unwittingly requesting X11 forwarding, which can warrant a ''no'' setting.
+X11 forwarding should be enabled with caution. Users with the ability to bypass file permissions on the remote host (for the user's X11 authorization database) can access the local X11 display through the forwarded connection. An attacker may then be able to perform activities such as keystroke monitoring if the ForwardX11Trusted option is also enabled.
+If X11 services are not required for the system's intended function, they should be disabled or restricted as appropriate to the system’s needs.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-33199r568412_fix">Edit the "/etc/ssh/sshd_config" file to uncomment or add the line for the "X11Forwarding" keyword and set its value to "no" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor):
+
+X11Forwarding no
+
+The SSH service must be restarted for changes to take effect:
+
+$ sudo systemctl restart sshd</fixtext><fix id="F-33199r568412_fix" /><check system="C-36965r608718_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify that X11Forwarding is disabled with the following command:
+
+# grep -i x11forwarding /etc/ssh/sshd_config | grep -v "^#"
+
+X11Forwarding no
+
+If the "X11Forwarding" keyword is set to "yes" and is not documented with the Information System Security Officer (ISSO) as an operational requirement or is missing, this is a finding.</check-content></check></Rule></Group><Group id="V-233780"><title>SRG-OS-000480-GPOS-00227</title><description>&lt;GroupDescription&gt;&lt;/GroupDescription&gt;</description><Rule id="SV-233780r610963_rule" severity="medium" weight="10.0"><version>UBTU-18-010419</version><title>The Ubuntu operating system SSH daemon must prevent remote hosts from connecting to the proxy display.</title><description>&lt;VulnDiscussion&gt;When X11 forwarding is enabled, there may be additional exposure to the server and client displays if the SSHD proxy display is configured to listen on the wildcard address. By default, SSHD binds the forwarding server to the loopback address and sets the hostname part of the DIPSLAY environment variable to localhost. This prevents remote hosts from connecting to the proxy display.&lt;/VulnDiscussion&gt;&lt;FalsePositives&gt;&lt;/FalsePositives&gt;&lt;FalseNegatives&gt;&lt;/FalseNegatives&gt;&lt;Documentable&gt;false&lt;/Documentable&gt;&lt;Mitigations&gt;&lt;/Mitigations&gt;&lt;SeverityOverrideGuidance&gt;&lt;/SeverityOverrideGuidance&gt;&lt;PotentialImpacts&gt;&lt;/PotentialImpacts&gt;&lt;ThirdPartyTools&gt;&lt;/ThirdPartyTools&gt;&lt;MitigationControl&gt;&lt;/MitigationControl&gt;&lt;Responsibility&gt;&lt;/Responsibility&gt;&lt;IAControls&gt;&lt;/IAControls&gt;</description><reference><dc:title>DPMS Target Canonical Ubuntu 18.04 LTS</dc:title><dc:publisher>DISA</dc:publisher><dc:type>DPMS Target</dc:type><dc:subject>Canonical Ubuntu 18.04 LTS</dc:subject><dc:identifier>4055</dc:identifier></reference><ident system="http://cyber.mil/cci">CCI-000366</ident><fixtext fixref="F-33200r568415_fix">Configure the SSH daemon to prevent remote hosts from connecting to the proxy display.
+
+Edit the "/etc/ssh/sshd_config" file to uncomment or add the line for the "X11UseLocalhost" keyword and set its value to "yes" (this file may be named differently or be in a different location if using a version of SSH that is provided by a third-party vendor):
+
+X11UseLocalhost yes</fixtext><fix id="F-33200r568415_fix" /><check system="C-36818r606414_chk"><check-content-ref href="Canonical_Ubuntu_18.04_LTS_STIG.xml" name="M" /><check-content>Verify the SSH daemon prevents remote hosts from connecting to the proxy display.
+
+Check the SSH X11UseLocalhost setting with the following command:
+
+# sudo grep -i x11uselocalhost /etc/ssh/sshd_config
+X11UseLocalhost yes
+
+If the "X11UseLocalhost" keyword is set to "no", is missing, or is commented out, this is a finding.</check-content></check></Rule></Group></Benchmark>

--- a/lib/happy_mapper_tools/stig_attributes.rb
+++ b/lib/happy_mapper_tools/stig_attributes.rb
@@ -77,6 +77,15 @@ module HappyMapperTools
       element :dc_identifier, String, tag: 'identifier', namespace: 'dc'
     end
 
+    class Ident
+      include HappyMapper
+      attr_accessor :legacy
+      attr_accessor :cci
+      tag 'ident'
+      attribute :system, String, tag: 'system'
+      content :ident, String
+    end
+
     class Rule
       include HappyMapper
       tag 'Rule'
@@ -87,7 +96,7 @@ module HappyMapperTools
       element :title, String, tag: 'title'
       has_one :description, Description, tag: 'description'
       element :reference, ReferenceInfo, tag: 'reference'
-      has_many :idents, String, tag: 'ident'
+      has_many :idents, Ident, tag: 'ident'
       element :fixtext, String, tag: 'fixtext'
       has_one :fix, Fix, tag: 'fix'
       has_one :check, Check, tag: 'check'

--- a/lib/utilities/inspec_util.rb
+++ b/lib/utilities/inspec_util.rb
@@ -246,6 +246,7 @@ module Utils
         control.add_tag(::Inspec::Object::Tag.new('stig_id',  json_control['tags']['stig_id']))
         control.add_tag(::Inspec::Object::Tag.new('fix_id', json_control['tags']['fix_id']))
         control.add_tag(::Inspec::Object::Tag.new('cci', json_control['tags']['cci']))
+        control.add_tag(::Inspec::Object::Tag.new('legacy', json_control['tags']['legacy']))
         control.add_tag(::Inspec::Object::Tag.new('nist', json_control['tags']['nist']))
         control.add_tag(::Inspec::Object::Tag.new('cis_level', json_control['tags']['cis_level'])) unless json_control['tags']['cis_level'].blank?
         control.add_tag(::Inspec::Object::Tag.new('cis_controls', json_control['tags']['cis_controls'])) unless json_control['tags']['cis_controls'].blank?


### PR DESCRIPTION
Create an additional `Ident` HappyMapper class and adds an `after_parse` callback that parses the `Ident` tag legacy identifier.

Closes #220 