### PR TITLE
to_xccdf: Enable STIGViewer support for automatic CCI descriptions.

### DIFF
--- a/lib/happy_mapper_tools/benchmark.rb
+++ b/lib/happy_mapper_tools/benchmark.rb
@@ -65,6 +65,14 @@ module HappyMapperTools
       tag 'ident'
       attribute :system, String, tag: 'system'
       content :ident, String
+      def initialize(ident_str)
+        @ident = ident_str
+	if ident_str =~ /^(CCI-[0-9]{6})$/
+          @system = 'http://cyber.mil/cci'
+	else
+          @system = 'http://cyber.mil/legacy'
+	end
+      end
     end
 
     # Class Fixtext maps from the 'fixtext' from Benchmark XML file using HappyMapper

--- a/lib/utilities/xccdf/from_inspec.rb
+++ b/lib/utilities/xccdf/from_inspec.rb
@@ -34,6 +34,7 @@ module Utils
         c_data[c_id]['rweight']        = control['tags']['rweight'] if control['tags']['rweight'] # Optional attribute where N/A is not schema compliant
         c_data[c_id]['stig_id']        = control['tags']['stig_id'] || DATA_NOT_FOUND_MESSAGE
         c_data[c_id]['cci']            = control['tags']['cci'] if control['tags']['cci'] # Optional attribute
+        c_data[c_id]['legacy']         = control['tags']['legacy'] if control['tags']['legacy'] # Optional attribute
         c_data[c_id]['nist']           = control['tags']['nist'] || ['unmapped']
         c_data[c_id]['check']          = control['tags']['check'] || DATA_NOT_FOUND_MESSAGE
         c_data[c_id]['checkref']       = control['tags']['checkref'] || DATA_NOT_FOUND_MESSAGE

--- a/lib/utilities/xccdf/to_xccdf.rb
+++ b/lib/utilities/xccdf/to_xccdf.rb
@@ -73,7 +73,9 @@ module Utils
           group.rule.reference = build_rule_reference
         end
 
-        group.rule.ident = build_rule_idents(control['cci']) if control['cci']
+        group.rule.ident = build_rule_idents(control['cci'], 'http://cyber.mil/cci') if control['cci']
+        # Usage of the "Legacy IDs" field in the DISA STIGViewer is still unknown
+        # group.rule.ident += build_rule_idents(control['legacy'], 'http://cyber.mil/legacy') if control['legacy']
 
         group.rule.fixtext = HappyMapperTools::Benchmark::Fixtext.new
         group.rule.fixtext.fixref = control['fix_id']
@@ -121,13 +123,14 @@ module Utils
 
     # Construct rule identifiers for rule
     # @param idents [Array]
-    def build_rule_idents(idents)
+    def build_rule_idents(idents, system)
       raise "#{idents} is not an Array type." unless idents.is_a?(Array)
 
       # Each rule identifier is a different element
       idents.map do |identifier|
         ident = HappyMapperTools::Benchmark::Ident.new
-        ident.system = 'https://public.cyber.mil/stigs/cci/'
+        # ident.system = 'http://cyber.mil/cci'
+        ident.system = system
         ident.ident = identifier
         ident
       end
@@ -226,7 +229,9 @@ module Utils
       rule_result.message = result_message(result, result_status) if result_message(result, result_status)
       rule_result.instance = result['code_desc']
 
-      rule_result.ident = build_rule_idents(control['cci']) if control['cci']
+      rule_result.ident = build_rule_idents(control['cci'], 'http://cyber.mil/cci') if control['cci']
+      # Usage of the "Legacy IDs" field in the DISA STIGViewer is still unknown
+      # rule_result.ident += build_rule_idents(control['legacy'], 'http://cyber.mil/legacy') if control['legacy']
 
       # Fix information is only necessary when there are failed tests
       rule_result.fix = build_rule_fix(control['fix_id']) if control['fix_id'] && result_status == 'fail'

--- a/lib/utilities/xccdf/to_xccdf.rb
+++ b/lib/utilities/xccdf/to_xccdf.rb
@@ -74,8 +74,7 @@ module Utils
         end
 
         group.rule.ident = build_rule_idents(control['cci'], 'http://cyber.mil/cci') if control['cci']
-        # Usage of the "Legacy IDs" field in the DISA STIGViewer is still unknown
-        # group.rule.ident += build_rule_idents(control['legacy'], 'http://cyber.mil/legacy') if control['legacy']
+        group.rule.ident += build_rule_idents(control['legacy'], 'http://cyber.mil/legacy') if control['legacy']
 
         group.rule.fixtext = HappyMapperTools::Benchmark::Fixtext.new
         group.rule.fixtext.fixref = control['fix_id']
@@ -230,8 +229,7 @@ module Utils
       rule_result.instance = result['code_desc']
 
       rule_result.ident = build_rule_idents(control['cci'], 'http://cyber.mil/cci') if control['cci']
-      # Usage of the "Legacy IDs" field in the DISA STIGViewer is still unknown
-      # rule_result.ident += build_rule_idents(control['legacy'], 'http://cyber.mil/legacy') if control['legacy']
+      rule_result.ident += build_rule_idents(control['legacy'], 'http://cyber.mil/legacy') if control['legacy']
 
       # Fix information is only necessary when there are failed tests
       rule_result.fix = build_rule_fix(control['fix_id']) if control['fix_id'] && result_status == 'fail'

--- a/lib/utilities/xccdf/to_xccdf.rb
+++ b/lib/utilities/xccdf/to_xccdf.rb
@@ -73,8 +73,8 @@ module Utils
           group.rule.reference = build_rule_reference
         end
 
-        group.rule.ident = build_rule_idents(control['cci'], 'http://cyber.mil/cci') if control['cci']
-        group.rule.ident += build_rule_idents(control['legacy'], 'http://cyber.mil/legacy') if control['legacy']
+        group.rule.ident = build_rule_idents(control['cci']) if control['cci']
+        group.rule.ident += build_rule_idents(control['legacy']) if control['legacy']
 
         group.rule.fixtext = HappyMapperTools::Benchmark::Fixtext.new
         group.rule.fixtext.fixref = control['fix_id']
@@ -122,16 +122,12 @@ module Utils
 
     # Construct rule identifiers for rule
     # @param idents [Array]
-    def build_rule_idents(idents, system)
+    def build_rule_idents(idents)
       raise "#{idents} is not an Array type." unless idents.is_a?(Array)
 
       # Each rule identifier is a different element
       idents.map do |identifier|
-        ident = HappyMapperTools::Benchmark::Ident.new
-        # ident.system = 'http://cyber.mil/cci'
-        ident.system = system
-        ident.ident = identifier
-        ident
+        ident = HappyMapperTools::Benchmark::Ident.new identifier
       end
     end
 
@@ -228,8 +224,8 @@ module Utils
       rule_result.message = result_message(result, result_status) if result_message(result, result_status)
       rule_result.instance = result['code_desc']
 
-      rule_result.ident = build_rule_idents(control['cci'], 'http://cyber.mil/cci') if control['cci']
-      rule_result.ident += build_rule_idents(control['legacy'], 'http://cyber.mil/legacy') if control['legacy']
+      rule_result.ident = build_rule_idents(control['cci']) if control['cci']
+      rule_result.ident += build_rule_idents(control['legacy']) if control['legacy']
 
       # Fix information is only necessary when there are failed tests
       rule_result.fix = build_rule_fix(control['fix_id']) if control['fix_id'] && result_status == 'fail'


### PR DESCRIPTION
XCCDF ident elements with CCI values should use a cyber.mil/cci system attribute to display correctly in STIG Viewer.

> Before:
> ![20210409_rule_with_public_cci](https://user-images.githubusercontent.com/7094088/114248838-68410800-995e-11eb-8078-7490335fd5af.png)

> After:
> ![20210409_rule_with_mil_cci](https://user-images.githubusercontent.com/7094088/114248848-70994300-995e-11eb-92aa-5bc1ad8b5aa0.png)

