### PR TITLE
Fix bucketing logic

### DIFF
--- a/lib/utilities/inspec_util.rb
+++ b/lib/utilities/inspec_util.rb
@@ -99,12 +99,12 @@ module Utils
       status_list = control[:status].uniq
       if control[:impact].to_f.zero?
         'Not_Applicable'
+      elsif (status_list.include?('error') || status_list.empty?) && for_summary
+        'Profile_Error'
       elsif status_list.include?('failed')
         'Open'
       elsif status_list.include?('passed')
         'NotAFinding'
-      elsif status_list.include?('error') && for_summary
-        'Profile_Error'
       else
         # profile skipped or profile error
         'Not_Reviewed'


### PR DESCRIPTION
Update to mirror Heimdall bucketing.
- If control has an `error` status, bucket it as `Profile Error` no matter what other statuses are
- If a control does not contain any results, bucket it as `Profile Error`


Signed-off-by: Rony Xavier <rxavier@mitre.org>