### PR TITLE
inspec2xccdf: Preserve newlines in description text.

### DIFF
--- a/lib/utilities/xccdf/to_xccdf.rb
+++ b/lib/utilities/xccdf/to_xccdf.rb
@@ -67,7 +67,7 @@ module Utils
         group.rule.weight = control['rweight']
         group.rule.version = control['rversion']
         group.rule.title = control['title'].tr("\n", ' ') if control['title']
-        group.rule.description = "<VulnDiscussion>#{control['desc'].tr("\n", ' ')}</VulnDiscussion><FalsePositives></FalsePositives><FalseNegatives></FalseNegatives><Documentable>false</Documentable><Mitigations></Mitigations><SeverityOverrideGuidance></SeverityOverrideGuidance><PotentialImpacts></PotentialImpacts><ThirdPartyTools></ThirdPartyTools><MitigationControl></MitigationControl><Responsibility></Responsibility><IAControls></IAControls>"
+        group.rule.description = "<VulnDiscussion>#{control['desc']}</VulnDiscussion><FalsePositives></FalsePositives><FalseNegatives></FalseNegatives><Documentable>false</Documentable><Mitigations></Mitigations><SeverityOverrideGuidance></SeverityOverrideGuidance><PotentialImpacts></PotentialImpacts><ThirdPartyTools></ThirdPartyTools><MitigationControl></MitigationControl><Responsibility></Responsibility><IAControls></IAControls>"
 
         if ['reference.dc.publisher', 'reference.dc.title', 'reference.dc.subject', 'reference.dc.type', 'reference.dc.identifier'].any? { |a| @attribute.key?(a) }
           group.rule.reference = build_rule_reference


### PR DESCRIPTION
Before:
![20210427-inspec2xccdf-desc-before](https://user-images.githubusercontent.com/7094088/116258180-5622e000-a73a-11eb-9bb1-212f60f2da11.png)

---

After:
![20210427-inspec2xccdf-desc-after](https://user-images.githubusercontent.com/7094088/116258357-7eaada00-a73a-11eb-9a33-2256d100ba63.png)
