### PR TITLE
Fixed issues with unstable inspec jsons

### DIFF
--- a/lib/inspec_tools/inspec.rb
+++ b/lib/inspec_tools/inspec.rb
@@ -15,7 +15,11 @@ require_relative '../utilities/xccdf/to_xccdf'
 module InspecTools
   class Inspec
     def initialize(inspec_json, metadata = {})
-      @json = JSON.parse(inspec_json.gsub(/\\+u0000/, ''))
+      begin
+        @json = JSON.parse(inspec_json.gsub(/\\+u0000/, ''))
+      rescue
+        raise "Unexpected file encoding, please encode the inspec json using UTF-8"
+      end
       @metadata = metadata
     end
 

--- a/lib/utilities/xccdf/to_xccdf.rb
+++ b/lib/utilities/xccdf/to_xccdf.rb
@@ -123,8 +123,11 @@ module Utils
     # Construct rule identifiers for rule
     # @param idents [Array]
     def build_rule_idents(idents)
+      if idents.is_a?(String)
+        idents = [idents]
+      end
       raise "#{idents} is not an Array type." unless idents.is_a?(Array)
-
+      
       # Each rule identifier is a different element
       idents.map do |identifier|
         HappyMapperTools::Benchmark::Ident.new identifier


### PR DESCRIPTION
- Created a detection for invalid file encodings while parsing the inspec json, raising an error.

- Created a detection for if "idents" was a string, and made it convert the string into an array.

Note: Ruby has trouble detecting if a file encoding is UTF-16LE or not, so the incorrect encoding is determined by if the "gsub" function in line 19 of inspec.rb throws its own error, which indicates a non-UTF-8 encoding.