### PR TITLE
Added conversion to array when string is detected on cci in csv2inspec

### DIFF
--- a/lib/inspec_tools/csv.rb
+++ b/lib/inspec_tools/csv.rb
@@ -74,10 +74,10 @@ module InspecTools
         control['tags']['nist'] = nist unless nist.nil? || nist.include?(nil)
         @mapping['control.tags'].each do |tag|
           if tag.first == 'cci'
-            if cci_number.is_a? String
-              control['tags'][tag.first] = [cci_number]
-            else
+            if cci_number.is_a? Array
               control['tags'][tag.first] = cci_number
+            else
+              control['tags'][tag.first] = [cci_number]
             end
             next
           end

--- a/lib/inspec_tools/csv.rb
+++ b/lib/inspec_tools/csv.rb
@@ -74,7 +74,11 @@ module InspecTools
         control['tags']['nist'] = nist unless nist.nil? || nist.include?(nil)
         @mapping['control.tags'].each do |tag|
           if tag.first == 'cci'
-            control['tags'][tag.first] = cci_number
+            if cci_number.is_a? String
+              control['tags'][tag.first] = [cci_number]
+            else
+              control['tags'][tag.first] = cci_number
+            end
             next
           end
           control['tags'][tag.first] = row[tag.last] unless row[tag.last].nil?


### PR DESCRIPTION
I used the examples to test the csv2inspec, and noticed that all of the ccis existed as a string.

Fix:
Added a case for if the cci was a string, in which it would convert it into an array.